### PR TITLE
Add leapfrog and internal namespaces

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: pkgdown
+          extra-packages: any::pkgdown, local::.
           needs: website
 
       - name: Deploy package

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ remotes::install_github("mrc-ide/frogger", upgrade = FALSE)
 * Add a test which proves that C++ code can be compiled standalone, one exists in dust that can be used as inspriration
 * Tidy data copying a tensor2 to matrix and a tensor n to array utility functions which should be used in C++ R interface "src/frogger.cpp"
 * Ensure input data is not copied, we can read from the data that R owns (as long as don't write to it)
+* Convert string flags to the model to enums if we need to switch on them in several places. This should make it easier to reason about in C++ world and isolate the string checking to a single place
 
 ## License
 

--- a/inst/include/frogger.hpp
+++ b/inst/include/frogger.hpp
@@ -22,6 +22,7 @@ void initialise_model_state(const Parameters<real_type> &pars,
   state.art_strat_adult.setZero();
   state.births = 0;
 }
+
 }
 
 template<typename real_type>
@@ -42,4 +43,5 @@ State<real_type> run_model(int time_steps, const Parameters<real_type> &pars) {
   }
   return state;
 }
+
 }

--- a/inst/include/frogger.hpp
+++ b/inst/include/frogger.hpp
@@ -5,41 +5,41 @@
 
 namespace leapfrog {
 
-  namespace internal {
+namespace internal {
 
-    template <typename real_type>
-    void initialise_model_state(const Parameters<real_type>& pars,
-                                State<real_type>& state) {
-      for (int g = 0; g < pars.num_genders; g++) {
-        for (int a = 0; a < pars.age_groups_pop; a++) {
-          state.total_population(a, g) = pars.base_pop(a, g);
-        }
-      }
-      state.natural_deaths.setZero();
-      state.hiv_population.setZero();
-      state.hiv_natural_deaths.setZero();
-      state.hiv_strat_adult.setZero();
-      state.art_strat_adult.setZero();
-      state.births = 0;
+template<typename real_type>
+void initialise_model_state(const Parameters<real_type> &pars,
+                            State<real_type> &state) {
+  for (int g = 0; g < pars.num_genders; g++) {
+    for (int a = 0; a < pars.age_groups_pop; a++) {
+      state.total_population(a, g) = pars.base_pop(a, g);
     }
   }
+  state.natural_deaths.setZero();
+  state.hiv_population.setZero();
+  state.hiv_natural_deaths.setZero();
+  state.hiv_strat_adult.setZero();
+  state.art_strat_adult.setZero();
+  state.births = 0;
+}
+}
 
-  template <typename real_type>
-  State<real_type> run_model(int time_steps, const Parameters<real_type>& pars) {
-    State<real_type> state(pars.age_groups_pop, pars.num_genders,
-                           pars.disease_stages, pars.age_groups_hiv,
-                           pars.treatment_stages);
+template<typename real_type>
+State<real_type> run_model(int time_steps, const Parameters<real_type> &pars) {
+  State<real_type> state(pars.age_groups_pop, pars.num_genders,
+                         pars.disease_stages, pars.age_groups_hiv,
+                         pars.treatment_stages);
 
-    internal::initialise_model_state(pars, state);
-    auto state_next = state;
-    internal::IntermediateData<real_type> intermediate(pars.age_groups_pop, pars.age_groups_hiv, pars.num_genders);
-    // Each time step is mid-point of the year
-    for (int step = 1; step <= time_steps; ++step) {
-      internal::run_general_pop_demographic_projection(step, pars, state, state_next, intermediate);
-      internal::run_hiv_pop_demographic_projection(step, pars, state, state_next, intermediate);
-      std::swap(state, state_next);
-      intermediate.reset();
-    }
-    return state;
+  internal::initialise_model_state(pars, state);
+  auto state_next = state;
+  internal::IntermediateData<real_type> intermediate(pars.age_groups_pop, pars.age_groups_hiv, pars.num_genders);
+  // Each time step is mid-point of the year
+  for (int step = 1; step <= time_steps; ++step) {
+    internal::run_general_pop_demographic_projection(step, pars, state, state_next, intermediate);
+    internal::run_hiv_pop_demographic_projection(step, pars, state, state_next, intermediate);
+    std::swap(state, state_next);
+    intermediate.reset();
   }
+  return state;
+}
 }

--- a/inst/include/frogger.hpp
+++ b/inst/include/frogger.hpp
@@ -3,37 +3,43 @@
 #include "general_demographic_projection.hpp"
 #include "hiv_demographic_projection.hpp"
 
-template <typename real_type>
-State<real_type> run_model(int time_steps, const Parameters<real_type>& pars) {
-  State<real_type> state(pars.age_groups_pop, pars.num_genders,
-                      pars.disease_stages, pars.age_groups_hiv,
-                      pars.treatment_stages);
+namespace leapfrog {
 
-  initialise_model_state(pars, state);
-  auto state_next = state;
-  IntermediateData<real_type> intermediate(pars.age_groups_pop, pars.age_groups_hiv, pars.num_genders);
-  // Each time step is mid-point of the year
-  for (int step = 1; step <= time_steps; ++step) {
-    run_general_pop_demographic_projection(step, pars, state, state_next, intermediate);
-    run_hiv_pop_demographic_projection(step, pars, state, state_next, intermediate);
-    std::swap(state, state_next);
-    intermediate.reset();
-  }
-  return state;
-}
+  namespace internal {
 
-template <typename real_type>
-void initialise_model_state(const Parameters<real_type>& pars,
-                            State<real_type>& state) {
-  for (int g = 0; g < pars.num_genders; g++) {
-    for (int a = 0; a < pars.age_groups_pop; a++) {
-      state.total_population(a, g) = pars.base_pop(a, g);
+    template <typename real_type>
+    void initialise_model_state(const Parameters<real_type>& pars,
+                                State<real_type>& state) {
+      for (int g = 0; g < pars.num_genders; g++) {
+        for (int a = 0; a < pars.age_groups_pop; a++) {
+          state.total_population(a, g) = pars.base_pop(a, g);
+        }
+      }
+      state.natural_deaths.setZero();
+      state.hiv_population.setZero();
+      state.hiv_natural_deaths.setZero();
+      state.hiv_strat_adult.setZero();
+      state.art_strat_adult.setZero();
+      state.births = 0;
     }
   }
-  state.natural_deaths.setZero();
-  state.hiv_population.setZero();
-  state.hiv_natural_deaths.setZero();
-  state.hiv_strat_adult.setZero();
-  state.art_strat_adult.setZero();
-  state.births = 0;
+
+  template <typename real_type>
+  State<real_type> run_model(int time_steps, const Parameters<real_type>& pars) {
+    State<real_type> state(pars.age_groups_pop, pars.num_genders,
+                           pars.disease_stages, pars.age_groups_hiv,
+                           pars.treatment_stages);
+
+    internal::initialise_model_state(pars, state);
+    auto state_next = state;
+    internal::IntermediateData<real_type> intermediate(pars.age_groups_pop, pars.age_groups_hiv, pars.num_genders);
+    // Each time step is mid-point of the year
+    for (int step = 1; step <= time_steps; ++step) {
+      internal::run_general_pop_demographic_projection(step, pars, state, state_next, intermediate);
+      internal::run_hiv_pop_demographic_projection(step, pars, state, state_next, intermediate);
+      std::swap(state, state_next);
+      intermediate.reset();
+    }
+    return state;
+  }
 }

--- a/inst/include/general_demographic_projection.hpp
+++ b/inst/include/general_demographic_projection.hpp
@@ -115,5 +115,6 @@ void run_fertility_and_infant_migration(int time_step,
     state_next.total_population(0, g) *= 1.0 + migration_rate_a0;
   }
 }
+
 }
 }

--- a/inst/include/general_demographic_projection.hpp
+++ b/inst/include/general_demographic_projection.hpp
@@ -4,116 +4,116 @@
 
 namespace leapfrog {
 
-  namespace internal {
+namespace internal {
 
-    template <typename real_type>
-    void run_general_pop_demographic_projection(int time_step,
-                                                const Parameters<real_type>& pars,
-                                                const State<real_type>& state_curr,
-                                                State<real_type>& state_next,
-                                                IntermediateData<real_type>& intermediate) {
-      run_ageing_and_mortality(time_step, pars, state_curr, state_next, intermediate);
-      run_migration(time_step, pars, state_curr, state_next, intermediate);
-      run_fertility_and_infant_migration(time_step, pars, state_curr, state_next,
-                                         intermediate);
+template<typename real_type>
+void run_general_pop_demographic_projection(int time_step,
+                                            const Parameters<real_type> &pars,
+                                            const State<real_type> &state_curr,
+                                            State<real_type> &state_next,
+                                            IntermediateData<real_type> &intermediate) {
+  run_ageing_and_mortality(time_step, pars, state_curr, state_next, intermediate);
+  run_migration(time_step, pars, state_curr, state_next, intermediate);
+  run_fertility_and_infant_migration(time_step, pars, state_curr, state_next,
+                                     intermediate);
+}
+
+template<typename real_type>
+void run_ageing_and_mortality(int time_step,
+                              const Parameters<real_type> &pars,
+                              const State<real_type> &state_curr,
+                              State<real_type> &state_next,
+                              IntermediateData<real_type> &intermediate) {
+  for (int g = 0; g < pars.num_genders; ++g) {
+    // Start at index 1 as we will add infant (age 0) births and deaths later
+    for (int a = 1; a < pars.age_groups_pop; ++a) {
+      state_next.natural_deaths(a, g) = state_curr.total_population(a - 1, g) *
+                                        (1.0 - pars.survival(a, g, time_step));
+      state_next.total_population(a, g) =
+          state_curr.total_population(a - 1, g) -
+          state_next.natural_deaths(a, g);
     }
 
-    template <typename real_type>
-    void run_ageing_and_mortality(int time_step,
-                                  const Parameters<real_type>& pars,
-                                  const State<real_type>& state_curr,
-                                  State<real_type>& state_next,
-                                  IntermediateData<real_type>& intermediate) {
-      for (int g = 0; g < pars.num_genders; ++g) {
-        // Start at index 1 as we will add infant (age 0) births and deaths later
-        for (int a = 1; a < pars.age_groups_pop; ++a) {
-          state_next.natural_deaths(a, g) = state_curr.total_population(a - 1, g) *
-                                            (1.0 - pars.survival(a, g, time_step));
-          state_next.total_population(a, g) =
-              state_curr.total_population(a - 1, g) -
-              state_next.natural_deaths(a, g);
-        }
-
-        // open age group
-        real_type natural_deaths_open_age =
-            state_curr.total_population(pars.age_groups_pop - 1, g) *
-            (1.0 - pars.survival(pars.age_groups_pop, g, time_step));
-        state_next.natural_deaths(pars.age_groups_pop - 1, g) +=
-            natural_deaths_open_age;
-        state_next.total_population(pars.age_groups_pop - 1, g) +=
-            state_curr.total_population(pars.age_groups_pop - 1, g) -
-            natural_deaths_open_age;
-      }
-    }
-
-    template <typename real_type>
-    void run_migration(int time_step,
-                       const Parameters<real_type>& pars,
-                       const State<real_type>& state_curr,
-                       State<real_type>& state_next,
-                       IntermediateData<real_type>& intermediate) {
-      for (int g = 0; g < pars.num_genders; ++g) {
-        // Migration for ages 1, 2, ... 79
-        for (int a = 1; a < pars.age_groups_pop - 1; ++a) {
-          // Get migration rate, as number of net migrants adjusted for survivorship
-          // to end of period. Divide by 2 as (on average) half of deaths will
-          // happen before they migrate. Then divide by total pop to get rate.
-          intermediate.migration_rate(a, g) = pars.net_migration(a, g, time_step) *
-                                              (1.0 + pars.survival(a, g, time_step)) *
-                                              0.5 / state_next.total_population(a, g);
-          state_next.total_population(a, g) *= 1.0 + intermediate.migration_rate(a, g);
-        }
-
-        // For open age group (age 80+), net migrant survivor adjustment based on
-        // weighted survival for age 79 and age 80+.
-        // * Numerator: total_population(a, g, t-1) * (1.0 + survival(a+1, g, t))
-        // + total_population(a-1, g, t-1) * (1.0 + survival(a, g, t))
-        // * Denominator: total_population(a, g, t-1) + total_population(a-1, g,
-        // t-1) Re-expressed current population and deaths to open age group
-        // (already calculated):
-        int a = pars.age_groups_pop - 1;
-        real_type survival_netmig =
-            (state_next.total_population(a, g) +
-             0.5 * state_next.natural_deaths(a, g)) /
-            (state_next.total_population(a, g) + state_next.natural_deaths(a, g));
-        intermediate.migration_rate(a, g) = survival_netmig *
-                                            pars.net_migration(a, g, time_step) /
-                                            state_next.total_population(a, g);
-        state_next.total_population(a, g) *= 1.0 + intermediate.migration_rate(a, g);
-      }
-    }
-
-    template <typename real_type>
-    void run_fertility_and_infant_migration(int time_step,
-                                            const Parameters<real_type>& pars,
-                                            const State<real_type>& state_curr,
-                                            State<real_type>& state_next,
-                                            IntermediateData<real_type>& intermediate) {
-      state_next.births = 0.0;
-      for (int af = 0; af < pars.age_groups_fert; ++af) {
-        state_next.births += (state_curr.total_population(
-            pars.fertility_first_age_group + af, FEMALE) +
-                              state_next.total_population(
-                                  pars.fertility_first_age_group + af, FEMALE)) *
-                             0.5 * pars.age_sex_fertility_ratio(af, time_step);
-      }
-
-      // add births & infant migration
-      for (int g = 0; g < pars.num_genders; ++g) {
-        real_type births_sex =
-            state_next.births * pars.births_sex_prop(g, time_step);
-        state_next.natural_deaths(0, g) =
-            births_sex * (1.0 - pars.survival(0, g, time_step));
-        state_next.total_population(0, g) =
-            births_sex * pars.survival(0, g, time_step);
-
-        // Assume 2/3 survival rate since mortality in first six months higher
-        // than second 6 months (Spectrum manual, section 6.2.7.4)
-        real_type migration_rate_a0 = pars.net_migration(0, g, time_step) *
-                                      (1.0 + 2.0 * pars.survival(0, g, time_step)) /
-                                      3.0 / state_next.total_population(0, g);
-        state_next.total_population(0, g) *= 1.0 + migration_rate_a0;
-      }
-    }
+    // open age group
+    real_type natural_deaths_open_age =
+        state_curr.total_population(pars.age_groups_pop - 1, g) *
+        (1.0 - pars.survival(pars.age_groups_pop, g, time_step));
+    state_next.natural_deaths(pars.age_groups_pop - 1, g) +=
+        natural_deaths_open_age;
+    state_next.total_population(pars.age_groups_pop - 1, g) +=
+        state_curr.total_population(pars.age_groups_pop - 1, g) -
+        natural_deaths_open_age;
   }
+}
+
+template<typename real_type>
+void run_migration(int time_step,
+                   const Parameters<real_type> &pars,
+                   const State<real_type> &state_curr,
+                   State<real_type> &state_next,
+                   IntermediateData<real_type> &intermediate) {
+  for (int g = 0; g < pars.num_genders; ++g) {
+    // Migration for ages 1, 2, ... 79
+    for (int a = 1; a < pars.age_groups_pop - 1; ++a) {
+      // Get migration rate, as number of net migrants adjusted for survivorship
+      // to end of period. Divide by 2 as (on average) half of deaths will
+      // happen before they migrate. Then divide by total pop to get rate.
+      intermediate.migration_rate(a, g) = pars.net_migration(a, g, time_step) *
+                                          (1.0 + pars.survival(a, g, time_step)) *
+                                          0.5 / state_next.total_population(a, g);
+      state_next.total_population(a, g) *= 1.0 + intermediate.migration_rate(a, g);
+    }
+
+    // For open age group (age 80+), net migrant survivor adjustment based on
+    // weighted survival for age 79 and age 80+.
+    // * Numerator: total_population(a, g, t-1) * (1.0 + survival(a+1, g, t))
+    // + total_population(a-1, g, t-1) * (1.0 + survival(a, g, t))
+    // * Denominator: total_population(a, g, t-1) + total_population(a-1, g,
+    // t-1) Re-expressed current population and deaths to open age group
+    // (already calculated):
+    int a = pars.age_groups_pop - 1;
+    real_type survival_netmig =
+        (state_next.total_population(a, g) +
+         0.5 * state_next.natural_deaths(a, g)) /
+        (state_next.total_population(a, g) + state_next.natural_deaths(a, g));
+    intermediate.migration_rate(a, g) = survival_netmig *
+                                        pars.net_migration(a, g, time_step) /
+                                        state_next.total_population(a, g);
+    state_next.total_population(a, g) *= 1.0 + intermediate.migration_rate(a, g);
+  }
+}
+
+template<typename real_type>
+void run_fertility_and_infant_migration(int time_step,
+                                        const Parameters<real_type> &pars,
+                                        const State<real_type> &state_curr,
+                                        State<real_type> &state_next,
+                                        IntermediateData<real_type> &intermediate) {
+  state_next.births = 0.0;
+  for (int af = 0; af < pars.age_groups_fert; ++af) {
+    state_next.births += (state_curr.total_population(
+        pars.fertility_first_age_group + af, FEMALE) +
+                          state_next.total_population(
+                              pars.fertility_first_age_group + af, FEMALE)) *
+                         0.5 * pars.age_sex_fertility_ratio(af, time_step);
+  }
+
+  // add births & infant migration
+  for (int g = 0; g < pars.num_genders; ++g) {
+    real_type births_sex =
+        state_next.births * pars.births_sex_prop(g, time_step);
+    state_next.natural_deaths(0, g) =
+        births_sex * (1.0 - pars.survival(0, g, time_step));
+    state_next.total_population(0, g) =
+        births_sex * pars.survival(0, g, time_step);
+
+    // Assume 2/3 survival rate since mortality in first six months higher
+    // than second 6 months (Spectrum manual, section 6.2.7.4)
+    real_type migration_rate_a0 = pars.net_migration(0, g, time_step) *
+                                  (1.0 + 2.0 * pars.survival(0, g, time_step)) /
+                                  3.0 / state_next.total_population(0, g);
+    state_next.total_population(0, g) *= 1.0 + migration_rate_a0;
+  }
+}
+}
 }

--- a/inst/include/general_demographic_projection.hpp
+++ b/inst/include/general_demographic_projection.hpp
@@ -2,112 +2,118 @@
 
 #include "types.hpp"
 
-template <typename real_type>
-void run_general_pop_demographic_projection(int time_step,
-                                        const Parameters<real_type>& pars,
-                                        const State<real_type>& state_curr,
-                                        State<real_type>& state_next,
-                                        IntermediateData<real_type>& intermediate) {
-  run_ageing_and_mortality(time_step, pars, state_curr, state_next, intermediate);
-  run_migration(time_step, pars, state_curr, state_next, intermediate);
-  run_fertility_and_infant_migration(time_step, pars, state_curr, state_next,
-                                     intermediate);
-}
+namespace leapfrog {
 
-template <typename real_type>
-void run_ageing_and_mortality(int time_step,
-                              const Parameters<real_type>& pars,
-                              const State<real_type>& state_curr,
-                              State<real_type>& state_next,
-                              IntermediateData<real_type>& intermediate) {
-  for (int g = 0; g < pars.num_genders; ++g) {
-    // Start at index 1 as we will add infant (age 0) births and deaths later
-    for (int a = 1; a < pars.age_groups_pop; ++a) {
-      state_next.natural_deaths(a, g) = state_curr.total_population(a - 1, g) *
-                                        (1.0 - pars.survival(a, g, time_step));
-      state_next.total_population(a, g) =
-          state_curr.total_population(a - 1, g) -
-          state_next.natural_deaths(a, g);
+  namespace internal {
+
+    template <typename real_type>
+    void run_general_pop_demographic_projection(int time_step,
+                                                const Parameters<real_type>& pars,
+                                                const State<real_type>& state_curr,
+                                                State<real_type>& state_next,
+                                                IntermediateData<real_type>& intermediate) {
+      run_ageing_and_mortality(time_step, pars, state_curr, state_next, intermediate);
+      run_migration(time_step, pars, state_curr, state_next, intermediate);
+      run_fertility_and_infant_migration(time_step, pars, state_curr, state_next,
+                                         intermediate);
     }
 
-    // open age group
-    real_type natural_deaths_open_age =
-        state_curr.total_population(pars.age_groups_pop - 1, g) *
-        (1.0 - pars.survival(pars.age_groups_pop, g, time_step));
-    state_next.natural_deaths(pars.age_groups_pop - 1, g) +=
-        natural_deaths_open_age;
-    state_next.total_population(pars.age_groups_pop - 1, g) +=
-        state_curr.total_population(pars.age_groups_pop - 1, g) -
-        natural_deaths_open_age;
-  }
-}
+    template <typename real_type>
+    void run_ageing_and_mortality(int time_step,
+                                  const Parameters<real_type>& pars,
+                                  const State<real_type>& state_curr,
+                                  State<real_type>& state_next,
+                                  IntermediateData<real_type>& intermediate) {
+      for (int g = 0; g < pars.num_genders; ++g) {
+        // Start at index 1 as we will add infant (age 0) births and deaths later
+        for (int a = 1; a < pars.age_groups_pop; ++a) {
+          state_next.natural_deaths(a, g) = state_curr.total_population(a - 1, g) *
+                                            (1.0 - pars.survival(a, g, time_step));
+          state_next.total_population(a, g) =
+              state_curr.total_population(a - 1, g) -
+              state_next.natural_deaths(a, g);
+        }
 
-template <typename real_type>
-void run_migration(int time_step,
-                   const Parameters<real_type>& pars,
-                   const State<real_type>& state_curr,
-                   State<real_type>& state_next,
-                   IntermediateData<real_type>& intermediate) {
-  for (int g = 0; g < pars.num_genders; ++g) {
-    // Migration for ages 1, 2, ... 79
-    for (int a = 1; a < pars.age_groups_pop - 1; ++a) {
-      // Get migration rate, as number of net migrants adjusted for survivorship
-      // to end of period. Divide by 2 as (on average) half of deaths will
-      // happen before they migrate. Then divide by total pop to get rate.
-      intermediate.migration_rate(a, g) = pars.net_migration(a, g, time_step) *
-                                     (1.0 + pars.survival(a, g, time_step)) *
-                                     0.5 / state_next.total_population(a, g);
-      state_next.total_population(a, g) *= 1.0 + intermediate.migration_rate(a, g);
+        // open age group
+        real_type natural_deaths_open_age =
+            state_curr.total_population(pars.age_groups_pop - 1, g) *
+            (1.0 - pars.survival(pars.age_groups_pop, g, time_step));
+        state_next.natural_deaths(pars.age_groups_pop - 1, g) +=
+            natural_deaths_open_age;
+        state_next.total_population(pars.age_groups_pop - 1, g) +=
+            state_curr.total_population(pars.age_groups_pop - 1, g) -
+            natural_deaths_open_age;
+      }
     }
 
-    // For open age group (age 80+), net migrant survivor adjustment based on
-    // weighted survival for age 79 and age 80+.
-    // * Numerator: total_population(a, g, t-1) * (1.0 + survival(a+1, g, t))
-    // + total_population(a-1, g, t-1) * (1.0 + survival(a, g, t))
-    // * Denominator: total_population(a, g, t-1) + total_population(a-1, g,
-    // t-1) Re-expressed current population and deaths to open age group
-    // (already calculated):
-    int a = pars.age_groups_pop - 1;
-    real_type survival_netmig =
-        (state_next.total_population(a, g) +
-         0.5 * state_next.natural_deaths(a, g)) /
-        (state_next.total_population(a, g) + state_next.natural_deaths(a, g));
-    intermediate.migration_rate(a, g) = survival_netmig *
-                                   pars.net_migration(a, g, time_step) /
-                                   state_next.total_population(a, g);
-    state_next.total_population(a, g) *= 1.0 + intermediate.migration_rate(a, g);
-  }
-}
+    template <typename real_type>
+    void run_migration(int time_step,
+                       const Parameters<real_type>& pars,
+                       const State<real_type>& state_curr,
+                       State<real_type>& state_next,
+                       IntermediateData<real_type>& intermediate) {
+      for (int g = 0; g < pars.num_genders; ++g) {
+        // Migration for ages 1, 2, ... 79
+        for (int a = 1; a < pars.age_groups_pop - 1; ++a) {
+          // Get migration rate, as number of net migrants adjusted for survivorship
+          // to end of period. Divide by 2 as (on average) half of deaths will
+          // happen before they migrate. Then divide by total pop to get rate.
+          intermediate.migration_rate(a, g) = pars.net_migration(a, g, time_step) *
+                                              (1.0 + pars.survival(a, g, time_step)) *
+                                              0.5 / state_next.total_population(a, g);
+          state_next.total_population(a, g) *= 1.0 + intermediate.migration_rate(a, g);
+        }
 
-template <typename real_type>
-void run_fertility_and_infant_migration(int time_step,
-                                        const Parameters<real_type>& pars,
-                                        const State<real_type>& state_curr,
-                                        State<real_type>& state_next,
-                                        IntermediateData<real_type>& intermediate) {
-  state_next.births = 0.0;
-  for (int af = 0; af < pars.age_groups_fert; ++af) {
-    state_next.births += (state_curr.total_population(
-                              pars.fertility_first_age_group + af, FEMALE) +
-                          state_next.total_population(
-                              pars.fertility_first_age_group + af, FEMALE)) *
-                         0.5 * pars.age_sex_fertility_ratio(af, time_step);
-  }
+        // For open age group (age 80+), net migrant survivor adjustment based on
+        // weighted survival for age 79 and age 80+.
+        // * Numerator: total_population(a, g, t-1) * (1.0 + survival(a+1, g, t))
+        // + total_population(a-1, g, t-1) * (1.0 + survival(a, g, t))
+        // * Denominator: total_population(a, g, t-1) + total_population(a-1, g,
+        // t-1) Re-expressed current population and deaths to open age group
+        // (already calculated):
+        int a = pars.age_groups_pop - 1;
+        real_type survival_netmig =
+            (state_next.total_population(a, g) +
+             0.5 * state_next.natural_deaths(a, g)) /
+            (state_next.total_population(a, g) + state_next.natural_deaths(a, g));
+        intermediate.migration_rate(a, g) = survival_netmig *
+                                            pars.net_migration(a, g, time_step) /
+                                            state_next.total_population(a, g);
+        state_next.total_population(a, g) *= 1.0 + intermediate.migration_rate(a, g);
+      }
+    }
 
-  // add births & infant migration
-  for (int g = 0; g < pars.num_genders; ++g) {
-    real_type births_sex =
-        state_next.births * pars.births_sex_prop(g, time_step);
-    state_next.natural_deaths(0, g) =
-        births_sex * (1.0 - pars.survival(0, g, time_step));
-    state_next.total_population(0, g) =
-        births_sex * pars.survival(0, g, time_step);
+    template <typename real_type>
+    void run_fertility_and_infant_migration(int time_step,
+                                            const Parameters<real_type>& pars,
+                                            const State<real_type>& state_curr,
+                                            State<real_type>& state_next,
+                                            IntermediateData<real_type>& intermediate) {
+      state_next.births = 0.0;
+      for (int af = 0; af < pars.age_groups_fert; ++af) {
+        state_next.births += (state_curr.total_population(
+            pars.fertility_first_age_group + af, FEMALE) +
+                              state_next.total_population(
+                                  pars.fertility_first_age_group + af, FEMALE)) *
+                             0.5 * pars.age_sex_fertility_ratio(af, time_step);
+      }
 
-    // Assume 2/3 survival rate since mortality in first six months higher
-    // than second 6 months (Spectrum manual, section 6.2.7.4)
-    real_type migration_rate_a0 = pars.net_migration(0, g, time_step) *
-                                  (1.0 + 2.0 * pars.survival(0, g, time_step)) /
-                                  3.0 / state_next.total_population(0, g);
-    state_next.total_population(0, g) *= 1.0 + migration_rate_a0;
+      // add births & infant migration
+      for (int g = 0; g < pars.num_genders; ++g) {
+        real_type births_sex =
+            state_next.births * pars.births_sex_prop(g, time_step);
+        state_next.natural_deaths(0, g) =
+            births_sex * (1.0 - pars.survival(0, g, time_step));
+        state_next.total_population(0, g) =
+            births_sex * pars.survival(0, g, time_step);
+
+        // Assume 2/3 survival rate since mortality in first six months higher
+        // than second 6 months (Spectrum manual, section 6.2.7.4)
+        real_type migration_rate_a0 = pars.net_migration(0, g, time_step) *
+                                      (1.0 + 2.0 * pars.survival(0, g, time_step)) /
+                                      3.0 / state_next.total_population(0, g);
+        state_next.total_population(0, g) *= 1.0 + migration_rate_a0;
+      }
+    }
   }
 }

--- a/inst/include/hiv_demographic_projection.hpp
+++ b/inst/include/hiv_demographic_projection.hpp
@@ -5,163 +5,165 @@
 
 namespace leapfrog {
 
-  namespace internal {
+namespace internal {
 
-    template<typename real_type>
-    void run_hiv_pop_demographic_projection(int time_step,
-                                            const Parameters <real_type> &pars,
-                                            const State <real_type> &state_curr,
-                                            State <real_type> &state_next,
-                                            IntermediateData <real_type> &intermediate) {
-      run_hiv_ageing_and_mortality(time_step, pars, state_curr, state_next,
-                                   intermediate);
-      run_hiv_and_art_stratified_ageing(time_step, pars, state_curr, state_next,
-                                        intermediate);
-      run_hiv_deaths_and_migration(time_step, pars, state_next, intermediate);
-      run_hiv_and_art_stratified_deaths_and_migration(time_step, pars, state_curr,
-                                                      state_next, intermediate);
+template<typename real_type>
+void run_hiv_pop_demographic_projection(int time_step,
+                                        const Parameters<real_type> &pars,
+                                        const State<real_type> &state_curr,
+                                        State<real_type> &state_next,
+                                        IntermediateData<real_type> &intermediate) {
+  run_hiv_ageing_and_mortality(time_step, pars, state_curr, state_next,
+                               intermediate);
+  run_hiv_and_art_stratified_ageing(time_step, pars, state_curr, state_next,
+                                    intermediate);
+  run_hiv_deaths_and_migration(time_step, pars, state_next, intermediate);
+  run_hiv_and_art_stratified_deaths_and_migration(time_step, pars, state_curr,
+                                                  state_next, intermediate);
+}
+
+template<typename real_type>
+void run_hiv_ageing_and_mortality(int time_step,
+                                  const Parameters<real_type> &pars,
+                                  const State<real_type> &state_curr,
+                                  State<real_type> &state_next,
+                                  IntermediateData<real_type> &intermediate) {
+  // Non-hiv deaths
+  for (int g = 0; g < pars.num_genders; ++g) {
+    for (int a = 1; a < pars.age_groups_pop; ++a) {
+      state_next.hiv_natural_deaths(a, g) =
+          state_curr.hiv_population(a - 1, g) *
+          (1.0 - pars.survival(a, g, time_step));
+      state_next.hiv_population(a, g) = state_curr.hiv_population(a - 1, g);
     }
 
-    template<typename real_type>
-    void run_hiv_ageing_and_mortality(int time_step,
-                                      const Parameters <real_type> &pars,
-                                      const State <real_type> &state_curr,
-                                      State <real_type> &state_next,
-                                      IntermediateData <real_type> &intermediate) {
-      // Non-hiv deaths
-      for (int g = 0; g < pars.num_genders; ++g) {
-        for (int a = 1; a < pars.age_groups_pop; ++a) {
-          state_next.hiv_natural_deaths(a, g) =
-              state_curr.hiv_population(a - 1, g) *
-              (1.0 - pars.survival(a, g, time_step));
-          state_next.hiv_population(a, g) = state_curr.hiv_population(a - 1, g);
-        }
-
-        // open age group
-        state_next.hiv_natural_deaths(pars.age_groups_pop - 1, g) +=
-            state_curr.hiv_population(pars.age_groups_pop - 1, g) *
-            (1.0 - pars.survival(pars.age_groups_pop, g, time_step));
-        state_next.hiv_population(pars.age_groups_pop - 1, g) +=
-            state_curr.hiv_population(pars.age_groups_pop - 1, g);
-      }
-    }
-
-    template<typename real_type>
-    void run_hiv_and_art_stratified_ageing(int time_step,
-                                           const Parameters <real_type> &pars,
-                                           const State <real_type> &state_curr,
-                                           State <real_type> &state_next,
-                                           IntermediateData <real_type> &intermediate) {
-      // age coarse stratified HIV population
-      for (int g = 0; g < pars.num_genders; ++g) {
-        int a = pars.hiv_adult_first_age_group;
-        // Note: loop stops at age_groups_hiv-1; no one ages out of the open-ended
-        // age group
-        for (int ha = 0; ha < (pars.age_groups_hiv - 1); ++ha) {
-          for (int i = 0; i < pars.age_groups_hiv_span(ha); ++i, ++a) {
-            // TODO: Is this just multiplying hiv_population by the size of the span? Should we just multiply this instead?
-            // We don't need i
-            intermediate.hiv_age_up_prob(ha, g) += state_curr.hiv_population(a, g);
-          }
-          if (intermediate.hiv_age_up_prob(ha, g) > 0) {
-            intermediate.hiv_age_up_prob(ha, g) =
-                state_curr.hiv_population(a - 1, g) / intermediate.hiv_age_up_prob(ha, g);
-          } else {
-            intermediate.hiv_age_up_prob(ha, g) = 0.0;
-          }
-        }
-
-        for (int ha = 1; ha < pars.age_groups_hiv; ++ha) {
-          for (int hm = 0; hm < pars.disease_stages; ++hm) {
-            state_next.hiv_strat_adult(hm, ha, g) =
-                ((1.0 - intermediate.hiv_age_up_prob(ha, g)) * state_curr.hiv_strat_adult(hm, ha, g)) +
-                (intermediate.hiv_age_up_prob(ha - 1, g) * state_curr.hiv_strat_adult(hm, ha - 1, g));
-            if (time_step > pars.time_art_start)
-              for (int hu = 0; hu < pars.treatment_stages; ++hu) {
-                state_next.art_strat_adult(hu, hm, ha, g) =
-                    ((1.0 - intermediate.hiv_age_up_prob(ha, g)) * state_curr.art_strat_adult(hu, hm, ha, g)) +
-                    (intermediate.hiv_age_up_prob(ha - 1, g) * state_curr.art_strat_adult(hu, hm, ha - 1, g));
-              }
-          }
-        }
-
-        // TODO: add HIV+ 15 year old entrants
-        for (int hm = 0; hm < pars.disease_stages; ++hm) {
-          state_next.hiv_strat_adult(hm, 0, g) =
-              (1.0 - intermediate.hiv_age_up_prob(0, g)) * state_curr.hiv_strat_adult(hm, 0, g);
-          // ADD HIV+ entrants here
-          if (time_step > pars.time_art_start) {
-            for (int hu = 0; hu < pars.treatment_stages; ++hu) {
-              state_next.art_strat_adult(hu, hm, 0, g) =
-                  (1.0 - intermediate.hiv_age_up_prob(0, g)) *
-                  state_curr.art_strat_adult(hu, hm, 0, g);
-              // ADD HIV+ entrants here
-              //       artpop_t(hu, hm, 0, g, t) += paedsurv_g *
-              //       paedsurv_artcd4dist(hu, hm, g, t) * entrantartcov(g, t);
-            }
-          }
-        }
-      }
-    }
-
-    template<typename real_type>
-    void run_hiv_deaths_and_migration(int time_step,
-                                      const Parameters <real_type> &pars,
-                                      State <real_type> &state_next,
-                                      IntermediateData <real_type> &intermediate) {
-      // remove non-HIV deaths and net migration from hiv_population
-      for (int g = 0; g < pars.num_genders; ++g) {
-        for (int a = 1; a < pars.age_groups_pop; ++a) {
-          state_next.hiv_population(a, g) -= state_next.hiv_natural_deaths(a, g);
-          intermediate.hiv_net_migration(a, g) =
-              state_next.hiv_population(a, g) * intermediate.migration_rate(a, g);
-          state_next.hiv_population(a, g) += intermediate.hiv_net_migration(a, g);
-        }
-      }
-    }
-
-    template<typename real_type>
-    void run_hiv_and_art_stratified_deaths_and_migration(
-        int time_step,
-        const Parameters <real_type> &pars,
-        const State <real_type> &state_curr,
-        State <real_type> &state_next,
-        IntermediateData <real_type> &intermediate) {
-      for (int g = 0; g < pars.num_genders; ++g) {
-        int a = pars.hiv_adult_first_age_group;
-        for (int ha = 0; ha < pars.age_groups_hiv; ++ha) {
-          for (int i = 0; i < pars.age_groups_hiv_span(ha); ++i, ++a) {
-            intermediate.hiv_population_coarse_ages(ha, g) += state_next.hiv_population(a, g);
-          }
-        }
-      }
-
-      // remove non-HIV deaths and net migration from adult stratified population
-      for (int g = 0; g < pars.num_genders; ++g) {
-        int a = pars.hiv_adult_first_age_group;
-        for (int ha = 0; ha < pars.age_groups_hiv; ++ha) {
-          real_type deaths_migrate = 0;
-          for (int i = 0; i < pars.age_groups_hiv_span(ha); ++i, ++a) {
-            deaths_migrate += (intermediate.hiv_net_migration(a, g) - state_next.hiv_natural_deaths(a, g));
-          }
-
-          real_type deaths_migrate_rate = 0.0;
-          if (intermediate.hiv_population_coarse_ages(ha, g) > 0) {
-            deaths_migrate_rate = deaths_migrate / intermediate.hiv_population_coarse_ages(ha, g);
-          }
-
-          for (int hm = 0; hm < pars.disease_stages; ++hm) {
-            state_next.hiv_strat_adult(hm, ha, g) *= 1.0 + deaths_migrate_rate;
-            if (time_step > pars.time_art_start) {
-              for (int hu = 0; hu < pars.treatment_stages; ++hu) {
-                state_next.art_strat_adult(hu, hm, ha, g) *=
-                    1.0 + deaths_migrate_rate;
-              }
-            }
-          }
-        }
-      }
-    }
-
+    // open age group
+    state_next.hiv_natural_deaths(pars.age_groups_pop - 1, g) +=
+        state_curr.hiv_population(pars.age_groups_pop - 1, g) *
+        (1.0 - pars.survival(pars.age_groups_pop, g, time_step));
+    state_next.hiv_population(pars.age_groups_pop - 1, g) +=
+        state_curr.hiv_population(pars.age_groups_pop - 1, g);
   }
+}
+
+template<typename real_type>
+void run_hiv_and_art_stratified_ageing(int time_step,
+                                       const Parameters<real_type> &pars,
+                                       const State<real_type> &state_curr,
+                                       State<real_type> &state_next,
+                                       IntermediateData<real_type> &intermediate) {
+  // age coarse stratified HIV population
+  for (int g = 0; g < pars.num_genders; ++g) {
+    int a = pars.hiv_adult_first_age_group;
+    // Note: loop stops at age_groups_hiv-1; no one ages out of the open-ended
+    // age group
+    for (int ha = 0; ha < (pars.age_groups_hiv - 1); ++ha) {
+      for (int i = 0; i < pars.age_groups_hiv_span(ha); ++i, ++a) {
+        // TODO: Is this just multiplying hiv_population by the size of the span? Should we just multiply this instead?
+        // We don't need i
+        intermediate.hiv_age_up_prob(ha, g) += state_curr.hiv_population(a, g);
+      }
+      if (intermediate.hiv_age_up_prob(ha, g) > 0) {
+        intermediate.hiv_age_up_prob(ha, g) =
+            state_curr.hiv_population(a - 1, g) / intermediate.hiv_age_up_prob(ha, g);
+      } else {
+        intermediate.hiv_age_up_prob(ha, g) = 0.0;
+      }
+    }
+
+    for (int ha = 1; ha < pars.age_groups_hiv; ++ha) {
+      for (int hm = 0; hm < pars.disease_stages; ++hm) {
+        state_next.hiv_strat_adult(hm, ha, g) =
+            ((1.0 - intermediate.hiv_age_up_prob(ha, g)) * state_curr.hiv_strat_adult(hm, ha, g)) +
+            (intermediate.hiv_age_up_prob(ha - 1, g) * state_curr.hiv_strat_adult(hm, ha - 1, g));
+        if (time_step > pars.time_art_start)
+          for (int hu = 0; hu < pars.treatment_stages; ++hu) {
+            state_next.art_strat_adult(hu, hm, ha, g) =
+                ((1.0 - intermediate.hiv_age_up_prob(ha, g)) *
+                 state_curr.art_strat_adult(hu, hm, ha, g)) +
+                (intermediate.hiv_age_up_prob(ha - 1, g) *
+                 state_curr.art_strat_adult(hu, hm, ha - 1, g));
+          }
+      }
+    }
+
+    // TODO: add HIV+ 15 year old entrants
+    for (int hm = 0; hm < pars.disease_stages; ++hm) {
+      state_next.hiv_strat_adult(hm, 0, g) =
+          (1.0 - intermediate.hiv_age_up_prob(0, g)) * state_curr.hiv_strat_adult(hm, 0, g);
+      // ADD HIV+ entrants here
+      if (time_step > pars.time_art_start) {
+        for (int hu = 0; hu < pars.treatment_stages; ++hu) {
+          state_next.art_strat_adult(hu, hm, 0, g) =
+              (1.0 - intermediate.hiv_age_up_prob(0, g)) *
+              state_curr.art_strat_adult(hu, hm, 0, g);
+          // ADD HIV+ entrants here
+          //       artpop_t(hu, hm, 0, g, t) += paedsurv_g *
+          //       paedsurv_artcd4dist(hu, hm, g, t) * entrantartcov(g, t);
+        }
+      }
+    }
+  }
+}
+
+template<typename real_type>
+void run_hiv_deaths_and_migration(int time_step,
+                                  const Parameters<real_type> &pars,
+                                  State<real_type> &state_next,
+                                  IntermediateData<real_type> &intermediate) {
+  // remove non-HIV deaths and net migration from hiv_population
+  for (int g = 0; g < pars.num_genders; ++g) {
+    for (int a = 1; a < pars.age_groups_pop; ++a) {
+      state_next.hiv_population(a, g) -= state_next.hiv_natural_deaths(a, g);
+      intermediate.hiv_net_migration(a, g) =
+          state_next.hiv_population(a, g) * intermediate.migration_rate(a, g);
+      state_next.hiv_population(a, g) += intermediate.hiv_net_migration(a, g);
+    }
+  }
+}
+
+template<typename real_type>
+void run_hiv_and_art_stratified_deaths_and_migration(
+    int time_step,
+    const Parameters<real_type> &pars,
+    const State<real_type> &state_curr,
+    State<real_type> &state_next,
+    IntermediateData<real_type> &intermediate) {
+  for (int g = 0; g < pars.num_genders; ++g) {
+    int a = pars.hiv_adult_first_age_group;
+    for (int ha = 0; ha < pars.age_groups_hiv; ++ha) {
+      for (int i = 0; i < pars.age_groups_hiv_span(ha); ++i, ++a) {
+        intermediate.hiv_population_coarse_ages(ha, g) += state_next.hiv_population(a, g);
+      }
+    }
+  }
+
+  // remove non-HIV deaths and net migration from adult stratified population
+  for (int g = 0; g < pars.num_genders; ++g) {
+    int a = pars.hiv_adult_first_age_group;
+    for (int ha = 0; ha < pars.age_groups_hiv; ++ha) {
+      real_type deaths_migrate = 0;
+      for (int i = 0; i < pars.age_groups_hiv_span(ha); ++i, ++a) {
+        deaths_migrate += (intermediate.hiv_net_migration(a, g) - state_next.hiv_natural_deaths(a, g));
+      }
+
+      real_type deaths_migrate_rate = 0.0;
+      if (intermediate.hiv_population_coarse_ages(ha, g) > 0) {
+        deaths_migrate_rate = deaths_migrate / intermediate.hiv_population_coarse_ages(ha, g);
+      }
+
+      for (int hm = 0; hm < pars.disease_stages; ++hm) {
+        state_next.hiv_strat_adult(hm, ha, g) *= 1.0 + deaths_migrate_rate;
+        if (time_step > pars.time_art_start) {
+          for (int hu = 0; hu < pars.treatment_stages; ++hu) {
+            state_next.art_strat_adult(hu, hm, ha, g) *=
+                1.0 + deaths_migrate_rate;
+          }
+        }
+      }
+    }
+  }
+}
+
+}
 }

--- a/inst/include/hiv_demographic_projection.hpp
+++ b/inst/include/hiv_demographic_projection.hpp
@@ -3,157 +3,165 @@
 #include <iostream>
 #include "types.hpp"
 
-template <typename real_type>
-void run_hiv_pop_demographic_projection(int time_step,
-                                        const Parameters<real_type>& pars,
-                                        const State<real_type>& state_curr,
-                                        State<real_type>& state_next,
-                                        IntermediateData<real_type>& intermediate) {
-  run_hiv_ageing_and_mortality(time_step, pars, state_curr, state_next,
-                               intermediate);
-  run_hiv_and_art_stratified_ageing(time_step, pars, state_curr, state_next,
-                                    intermediate);
-  run_hiv_deaths_and_migration(time_step, pars, state_next, intermediate);
-  run_hiv_and_art_stratified_deaths_and_migration(time_step, pars, state_curr,
-                                                  state_next, intermediate);
-}
+namespace leapfrog {
 
-template <typename real_type>
-void run_hiv_ageing_and_mortality(int time_step,
-                                  const Parameters<real_type>& pars,
-                                  const State<real_type>& state_curr,
-                                  State<real_type>& state_next,
-                                  IntermediateData<real_type>& intermediate) {
-  // Non-hiv deaths
-  for (int g = 0; g < pars.num_genders; ++g) {
-    for (int a = 1; a < pars.age_groups_pop; ++a) {
-      state_next.hiv_natural_deaths(a, g) =
-          state_curr.hiv_population(a - 1, g) *
-          (1.0 - pars.survival(a, g, time_step));
-      state_next.hiv_population(a, g) = state_curr.hiv_population(a - 1, g);
+  namespace internal {
+
+    template<typename real_type>
+    void run_hiv_pop_demographic_projection(int time_step,
+                                            const Parameters <real_type> &pars,
+                                            const State <real_type> &state_curr,
+                                            State <real_type> &state_next,
+                                            IntermediateData <real_type> &intermediate) {
+      run_hiv_ageing_and_mortality(time_step, pars, state_curr, state_next,
+                                   intermediate);
+      run_hiv_and_art_stratified_ageing(time_step, pars, state_curr, state_next,
+                                        intermediate);
+      run_hiv_deaths_and_migration(time_step, pars, state_next, intermediate);
+      run_hiv_and_art_stratified_deaths_and_migration(time_step, pars, state_curr,
+                                                      state_next, intermediate);
     }
 
-    // open age group
-    state_next.hiv_natural_deaths(pars.age_groups_pop - 1, g) +=
-        state_curr.hiv_population(pars.age_groups_pop - 1, g) *
-        (1.0 - pars.survival(pars.age_groups_pop, g, time_step));
-    state_next.hiv_population(pars.age_groups_pop - 1, g) +=
-        state_curr.hiv_population(pars.age_groups_pop - 1, g);
-  }
-}
+    template<typename real_type>
+    void run_hiv_ageing_and_mortality(int time_step,
+                                      const Parameters <real_type> &pars,
+                                      const State <real_type> &state_curr,
+                                      State <real_type> &state_next,
+                                      IntermediateData <real_type> &intermediate) {
+      // Non-hiv deaths
+      for (int g = 0; g < pars.num_genders; ++g) {
+        for (int a = 1; a < pars.age_groups_pop; ++a) {
+          state_next.hiv_natural_deaths(a, g) =
+              state_curr.hiv_population(a - 1, g) *
+              (1.0 - pars.survival(a, g, time_step));
+          state_next.hiv_population(a, g) = state_curr.hiv_population(a - 1, g);
+        }
 
-template <typename real_type>
-void run_hiv_and_art_stratified_ageing(int time_step,
-                                       const Parameters<real_type>& pars,
-                                       const State<real_type>& state_curr,
-                                       State<real_type>& state_next,
-                                       IntermediateData<real_type>& intermediate) {
-  // age coarse stratified HIV population
-  for (int g = 0; g < pars.num_genders; ++g) {
-    int a = pars.hiv_adult_first_age_group;
-    // Note: loop stops at age_groups_hiv-1; no one ages out of the open-ended
-    // age group
-    for (int ha = 0; ha < (pars.age_groups_hiv - 1); ++ha) {
-      for (int i = 0; i < pars.age_groups_hiv_span(ha); ++i, ++a) {
-        // TODO: Is this just multiplying hiv_population by the size of the span? Should we just multiply this instead?
-        // We don't need i
-        intermediate.hiv_age_up_prob(ha, g) += state_curr.hiv_population(a, g);
-      }
-      if (intermediate.hiv_age_up_prob(ha, g) > 0) {
-        intermediate.hiv_age_up_prob(ha, g) = state_curr.hiv_population(a - 1, g) / intermediate.hiv_age_up_prob(ha, g);
-      } else {
-        intermediate.hiv_age_up_prob(ha, g) = 0.0;
+        // open age group
+        state_next.hiv_natural_deaths(pars.age_groups_pop - 1, g) +=
+            state_curr.hiv_population(pars.age_groups_pop - 1, g) *
+            (1.0 - pars.survival(pars.age_groups_pop, g, time_step));
+        state_next.hiv_population(pars.age_groups_pop - 1, g) +=
+            state_curr.hiv_population(pars.age_groups_pop - 1, g);
       }
     }
 
-    for (int ha = 1; ha < pars.age_groups_hiv; ++ha) {
-      for (int hm = 0; hm < pars.disease_stages; ++hm) {
-        state_next.hiv_strat_adult(hm, ha, g) =
-            ((1.0 - intermediate.hiv_age_up_prob(ha, g)) * state_curr.hiv_strat_adult(hm, ha, g)) +
-            (intermediate.hiv_age_up_prob(ha - 1, g) * state_curr.hiv_strat_adult(hm, ha - 1, g));
-        if (time_step > pars.time_art_start)
-          for (int hu = 0; hu < pars.treatment_stages; ++hu) {
-            state_next.art_strat_adult(hu, hm, ha, g) =
-                ((1.0 - intermediate.hiv_age_up_prob(ha, g)) * state_curr.art_strat_adult(hu, hm, ha, g)) +
-                (intermediate.hiv_age_up_prob(ha - 1, g) * state_curr.art_strat_adult(hu, hm, ha - 1, g));
+    template<typename real_type>
+    void run_hiv_and_art_stratified_ageing(int time_step,
+                                           const Parameters <real_type> &pars,
+                                           const State <real_type> &state_curr,
+                                           State <real_type> &state_next,
+                                           IntermediateData <real_type> &intermediate) {
+      // age coarse stratified HIV population
+      for (int g = 0; g < pars.num_genders; ++g) {
+        int a = pars.hiv_adult_first_age_group;
+        // Note: loop stops at age_groups_hiv-1; no one ages out of the open-ended
+        // age group
+        for (int ha = 0; ha < (pars.age_groups_hiv - 1); ++ha) {
+          for (int i = 0; i < pars.age_groups_hiv_span(ha); ++i, ++a) {
+            // TODO: Is this just multiplying hiv_population by the size of the span? Should we just multiply this instead?
+            // We don't need i
+            intermediate.hiv_age_up_prob(ha, g) += state_curr.hiv_population(a, g);
           }
-      }
-    }
+          if (intermediate.hiv_age_up_prob(ha, g) > 0) {
+            intermediate.hiv_age_up_prob(ha, g) =
+                state_curr.hiv_population(a - 1, g) / intermediate.hiv_age_up_prob(ha, g);
+          } else {
+            intermediate.hiv_age_up_prob(ha, g) = 0.0;
+          }
+        }
 
-    // TODO: add HIV+ 15 year old entrants
-    for (int hm = 0; hm < pars.disease_stages; ++hm) {
-      state_next.hiv_strat_adult(hm, 0, g) =
-          (1.0 - intermediate.hiv_age_up_prob(0, g)) * state_curr.hiv_strat_adult(hm, 0, g);
-      // ADD HIV+ entrants here
-      if (time_step > pars.time_art_start) {
-        for (int hu = 0; hu < pars.treatment_stages; ++hu) {
-          state_next.art_strat_adult(hu, hm, 0, g) =
-              (1.0 - intermediate.hiv_age_up_prob(0, g)) *
-              state_curr.art_strat_adult(hu, hm, 0, g);
+        for (int ha = 1; ha < pars.age_groups_hiv; ++ha) {
+          for (int hm = 0; hm < pars.disease_stages; ++hm) {
+            state_next.hiv_strat_adult(hm, ha, g) =
+                ((1.0 - intermediate.hiv_age_up_prob(ha, g)) * state_curr.hiv_strat_adult(hm, ha, g)) +
+                (intermediate.hiv_age_up_prob(ha - 1, g) * state_curr.hiv_strat_adult(hm, ha - 1, g));
+            if (time_step > pars.time_art_start)
+              for (int hu = 0; hu < pars.treatment_stages; ++hu) {
+                state_next.art_strat_adult(hu, hm, ha, g) =
+                    ((1.0 - intermediate.hiv_age_up_prob(ha, g)) * state_curr.art_strat_adult(hu, hm, ha, g)) +
+                    (intermediate.hiv_age_up_prob(ha - 1, g) * state_curr.art_strat_adult(hu, hm, ha - 1, g));
+              }
+          }
+        }
+
+        // TODO: add HIV+ 15 year old entrants
+        for (int hm = 0; hm < pars.disease_stages; ++hm) {
+          state_next.hiv_strat_adult(hm, 0, g) =
+              (1.0 - intermediate.hiv_age_up_prob(0, g)) * state_curr.hiv_strat_adult(hm, 0, g);
           // ADD HIV+ entrants here
-          //       artpop_t(hu, hm, 0, g, t) += paedsurv_g *
-          //       paedsurv_artcd4dist(hu, hm, g, t) * entrantartcov(g, t);
-        }
-      }
-    }
-  }
-}
-
-template <typename real_type>
-void run_hiv_deaths_and_migration(int time_step,
-                                  const Parameters<real_type>& pars,
-                                  State<real_type>& state_next,
-                                  IntermediateData<real_type>& intermediate) {
-  // remove non-HIV deaths and net migration from hiv_population
-  for (int g = 0; g < pars.num_genders; ++g) {
-    for (int a = 1; a < pars.age_groups_pop; ++a) {
-      state_next.hiv_population(a, g) -= state_next.hiv_natural_deaths(a, g);
-      intermediate.hiv_net_migration(a, g) =
-          state_next.hiv_population(a, g) * intermediate.migration_rate(a, g);
-      state_next.hiv_population(a, g) += intermediate.hiv_net_migration(a, g);
-    }
-  }
-}
-
-template <typename real_type>
-void run_hiv_and_art_stratified_deaths_and_migration(
-    int time_step,
-    const Parameters<real_type>& pars,
-    const State<real_type>& state_curr,
-    State<real_type>& state_next,
-    IntermediateData<real_type>& intermediate) {
-  for (int g = 0; g < pars.num_genders; ++g) {
-    int a = pars.hiv_adult_first_age_group;
-    for (int ha = 0; ha < pars.age_groups_hiv; ++ha) {
-      for (int i = 0; i < pars.age_groups_hiv_span(ha); ++i, ++a) {
-        intermediate.hiv_population_coarse_ages(ha, g) += state_next.hiv_population(a, g);
-      }
-    }
-  }
-
-  // remove non-HIV deaths and net migration from adult stratified population
-  for (int g = 0; g < pars.num_genders; ++g) {
-    int a = pars.hiv_adult_first_age_group;
-    for (int ha = 0; ha < pars.age_groups_hiv; ++ha) {
-      real_type deaths_migrate = 0;
-      for (int i = 0; i < pars.age_groups_hiv_span(ha); ++i, ++a) {
-        deaths_migrate += (intermediate.hiv_net_migration(a, g) - state_next.hiv_natural_deaths(a, g));
-      }
-
-      real_type deaths_migrate_rate = 0.0;
-      if (intermediate.hiv_population_coarse_ages(ha, g) > 0) {
-        deaths_migrate_rate = deaths_migrate / intermediate.hiv_population_coarse_ages(ha, g);
-      }
-
-      for (int hm = 0; hm < pars.disease_stages; ++hm) {
-        state_next.hiv_strat_adult(hm, ha, g) *= 1.0 + deaths_migrate_rate;
-        if (time_step > pars.time_art_start) {
-          for (int hu = 0; hu < pars.treatment_stages; ++hu) {
-            state_next.art_strat_adult(hu, hm, ha, g) *=
-                1.0 + deaths_migrate_rate;
+          if (time_step > pars.time_art_start) {
+            for (int hu = 0; hu < pars.treatment_stages; ++hu) {
+              state_next.art_strat_adult(hu, hm, 0, g) =
+                  (1.0 - intermediate.hiv_age_up_prob(0, g)) *
+                  state_curr.art_strat_adult(hu, hm, 0, g);
+              // ADD HIV+ entrants here
+              //       artpop_t(hu, hm, 0, g, t) += paedsurv_g *
+              //       paedsurv_artcd4dist(hu, hm, g, t) * entrantartcov(g, t);
+            }
           }
         }
       }
     }
+
+    template<typename real_type>
+    void run_hiv_deaths_and_migration(int time_step,
+                                      const Parameters <real_type> &pars,
+                                      State <real_type> &state_next,
+                                      IntermediateData <real_type> &intermediate) {
+      // remove non-HIV deaths and net migration from hiv_population
+      for (int g = 0; g < pars.num_genders; ++g) {
+        for (int a = 1; a < pars.age_groups_pop; ++a) {
+          state_next.hiv_population(a, g) -= state_next.hiv_natural_deaths(a, g);
+          intermediate.hiv_net_migration(a, g) =
+              state_next.hiv_population(a, g) * intermediate.migration_rate(a, g);
+          state_next.hiv_population(a, g) += intermediate.hiv_net_migration(a, g);
+        }
+      }
+    }
+
+    template<typename real_type>
+    void run_hiv_and_art_stratified_deaths_and_migration(
+        int time_step,
+        const Parameters <real_type> &pars,
+        const State <real_type> &state_curr,
+        State <real_type> &state_next,
+        IntermediateData <real_type> &intermediate) {
+      for (int g = 0; g < pars.num_genders; ++g) {
+        int a = pars.hiv_adult_first_age_group;
+        for (int ha = 0; ha < pars.age_groups_hiv; ++ha) {
+          for (int i = 0; i < pars.age_groups_hiv_span(ha); ++i, ++a) {
+            intermediate.hiv_population_coarse_ages(ha, g) += state_next.hiv_population(a, g);
+          }
+        }
+      }
+
+      // remove non-HIV deaths and net migration from adult stratified population
+      for (int g = 0; g < pars.num_genders; ++g) {
+        int a = pars.hiv_adult_first_age_group;
+        for (int ha = 0; ha < pars.age_groups_hiv; ++ha) {
+          real_type deaths_migrate = 0;
+          for (int i = 0; i < pars.age_groups_hiv_span(ha); ++i, ++a) {
+            deaths_migrate += (intermediate.hiv_net_migration(a, g) - state_next.hiv_natural_deaths(a, g));
+          }
+
+          real_type deaths_migrate_rate = 0.0;
+          if (intermediate.hiv_population_coarse_ages(ha, g) > 0) {
+            deaths_migrate_rate = deaths_migrate / intermediate.hiv_population_coarse_ages(ha, g);
+          }
+
+          for (int hm = 0; hm < pars.disease_stages; ++hm) {
+            state_next.hiv_strat_adult(hm, ha, g) *= 1.0 + deaths_migrate_rate;
+            if (time_step > pars.time_art_start) {
+              for (int hu = 0; hu < pars.treatment_stages; ++hu) {
+                state_next.art_strat_adult(hu, hm, ha, g) *=
+                    1.0 + deaths_migrate_rate;
+              }
+            }
+          }
+        }
+      }
+    }
+
   }
 }

--- a/inst/include/types.hpp
+++ b/inst/include/types.hpp
@@ -25,17 +25,24 @@ using Tensor4 = Eigen::Tensor<real_type, 4>;
 template<typename real_type>
 struct Parameters {
   int num_genders;
-  int age_groups_pop;             // Default 81 for ages 0 to 80+
-  int fertility_first_age_group;  // First index of population eligible for
-  // fertility
-  int age_groups_fert;            // Number of ages eligible for fertility
-  int age_groups_hiv;             // Numer of age groups in HIV population
-  int disease_stages;             // Number of HIV disease stages
-  int hiv_adult_first_age_group;  // First index of HIV population to model as
-  // adult
-  int treatment_stages;           // Number of HIV ART treatment stages
-  int time_art_start;             // Time step to start ART treatment
-  TensorMap1<int> age_groups_hiv_span;  // Number of years in each HIV age group
+  // Default 81 for ages 0 to 80+
+  int age_groups_pop;
+  // First index of population eligible for fertility
+  int fertility_first_age_group;
+  // Number of ages eligible for fertility
+  int age_groups_fert;
+  // Numer of age groups in HIV population
+  int age_groups_hiv;
+  // Number of HIV disease stages
+  int disease_stages;
+  // First index of HIV population to model as adult
+  int hiv_adult_first_age_group;
+  // Number of HIV ART treatment stages
+  int treatment_stages;
+  // Time step to start ART treatment
+  int time_art_start;
+  // Number of years in each HIV age group
+  TensorMap1<int> age_groups_hiv_span;
 
   TensorMap2<real_type> base_pop;
   TensorMap3<real_type> survival;

--- a/inst/include/types.hpp
+++ b/inst/include/types.hpp
@@ -2,91 +2,97 @@
 
 #include <unsupported/Eigen/CXX11/Tensor>
 
-const int MALE = 0;
-const int FEMALE = 1;
+namespace leapfrog {
 
-template <typename real_type>
-using TensorMap1 = Eigen::TensorMap<Eigen::Tensor<real_type, 1>>;
-template <typename real_type>
-using TensorMap2 = Eigen::TensorMap<Eigen::Tensor<real_type, 2>>;
+  template<typename real_type>
+  using TensorMap1 = Eigen::TensorMap <Eigen::Tensor<real_type, 1>>;
 
-template <typename real_type>
-using TensorMap3 = Eigen::TensorMap<Eigen::Tensor<real_type, 3>>;
+  template<typename real_type>
+  using TensorMap2 = Eigen::TensorMap <Eigen::Tensor<real_type, 2>>;
 
-template <typename real_type>
-using Tensor2 = Eigen::Tensor<real_type, 2>;
+  template<typename real_type>
+  using TensorMap3 = Eigen::TensorMap <Eigen::Tensor<real_type, 3>>;
 
-template <typename real_type>
-using Tensor3 = Eigen::Tensor<real_type, 3>;
+  template<typename real_type>
+  using Tensor2 = Eigen::Tensor<real_type, 2>;
 
-template <typename real_type>
-using Tensor4 = Eigen::Tensor<real_type, 4>;
+  template<typename real_type>
+  using Tensor3 = Eigen::Tensor<real_type, 3>;
 
-template <typename real_type>
-struct Parameters {
-  int num_genders;
-  int age_groups_pop;             // Default 81 for ages 0 to 80+
-  int fertility_first_age_group;  // First index of population eligible for
-                                  // fertility
-  int age_groups_fert;            // Number of ages eligible for fertility
-  int age_groups_hiv;             // Numer of age groups in HIV population
-  int disease_stages;             // Number of HIV disease stages
-  int hiv_adult_first_age_group;  // First index of HIV population to model as
-                                  // adult
-  int treatment_stages;           // Number of HIV ART treatment stages
-  int time_art_start;             // Time step to start ART treatment
-  TensorMap1<int> age_groups_hiv_span;  // Number of years in each HIV age group
+  template<typename real_type>
+  using Tensor4 = Eigen::Tensor<real_type, 4>;
 
-  TensorMap2<real_type> base_pop;
-  TensorMap3<real_type> survival;
-  TensorMap3<real_type> net_migration;
-  TensorMap2<real_type> age_sex_fertility_ratio;
-  TensorMap2<real_type> births_sex_prop;
-};
+  template<typename real_type>
+  struct Parameters {
+    int num_genders;
+    int age_groups_pop;             // Default 81 for ages 0 to 80+
+    int fertility_first_age_group;  // First index of population eligible for
+    // fertility
+    int age_groups_fert;            // Number of ages eligible for fertility
+    int age_groups_hiv;             // Numer of age groups in HIV population
+    int disease_stages;             // Number of HIV disease stages
+    int hiv_adult_first_age_group;  // First index of HIV population to model as
+    // adult
+    int treatment_stages;           // Number of HIV ART treatment stages
+    int time_art_start;             // Time step to start ART treatment
+    TensorMap1<int> age_groups_hiv_span;  // Number of years in each HIV age group
 
-template <typename real_type>
-struct State {
-  Tensor2<real_type> total_population;
-  Tensor2<real_type> natural_deaths;
-  Tensor2<real_type> hiv_population;
-  Tensor2<real_type> hiv_natural_deaths;
-  Tensor3<real_type> hiv_strat_adult;
-  Tensor4<real_type> art_strat_adult;
-  real_type births;
+    TensorMap2<real_type> base_pop;
+    TensorMap3<real_type> survival;
+    TensorMap3<real_type> net_migration;
+    TensorMap2<real_type> age_sex_fertility_ratio;
+    TensorMap2<real_type> births_sex_prop;
+  };
 
-  State(int age_groups_pop,
-        int num_genders,
-        int disease_stages,
-        int age_groups_hiv,
-        int treatment_stages)
-      : total_population(age_groups_pop, num_genders),
-        natural_deaths(age_groups_pop, num_genders),
-        hiv_population(age_groups_pop, num_genders),
-        hiv_natural_deaths(age_groups_pop, num_genders),
-        hiv_strat_adult(disease_stages, age_groups_hiv, num_genders),
-        art_strat_adult(treatment_stages,
-                        disease_stages,
-                        age_groups_hiv,
-                        num_genders) {}
-};
+  template<typename real_type>
+  struct State {
+    Tensor2<real_type> total_population;
+    Tensor2<real_type> natural_deaths;
+    Tensor2<real_type> hiv_population;
+    Tensor2<real_type> hiv_natural_deaths;
+    Tensor3<real_type> hiv_strat_adult;
+    Tensor4<real_type> art_strat_adult;
+    real_type births;
 
-template <typename real_type>
-struct IntermediateData {
-  Tensor2<real_type> migration_rate;
-  Tensor2<real_type> hiv_net_migration;
-  Tensor2<real_type> hiv_population_coarse_ages;
-  Tensor2<real_type> hiv_age_up_prob;
+    State(int age_groups_pop,
+          int num_genders,
+          int disease_stages,
+          int age_groups_hiv,
+          int treatment_stages)
+        : total_population(age_groups_pop, num_genders),
+          natural_deaths(age_groups_pop, num_genders),
+          hiv_population(age_groups_pop, num_genders),
+          hiv_natural_deaths(age_groups_pop, num_genders),
+          hiv_strat_adult(disease_stages, age_groups_hiv, num_genders),
+          art_strat_adult(treatment_stages,
+                          disease_stages,
+                          age_groups_hiv,
+                          num_genders) {}
+  };
 
-  IntermediateData(int age_groups_pop, int age_groups_hiv, int num_genders)
-      : migration_rate(age_groups_pop, num_genders),
-        hiv_net_migration(age_groups_pop, num_genders),
-        hiv_population_coarse_ages(age_groups_hiv, num_genders),
-        hiv_age_up_prob(age_groups_hiv, num_genders) {}
+  namespace internal {
+    const int MALE = 0;
+    const int FEMALE = 1;
 
-  void reset() {
-    migration_rate.setZero();
-    hiv_net_migration.setZero();
-    hiv_population_coarse_ages.setZero();
-    hiv_age_up_prob.setZero();
+    template<typename real_type>
+    struct IntermediateData {
+      Tensor2<real_type> migration_rate;
+      Tensor2<real_type> hiv_net_migration;
+      Tensor2<real_type> hiv_population_coarse_ages;
+      Tensor2<real_type> hiv_age_up_prob;
+
+      IntermediateData(int age_groups_pop, int age_groups_hiv, int num_genders)
+          : migration_rate(age_groups_pop, num_genders),
+            hiv_net_migration(age_groups_pop, num_genders),
+            hiv_population_coarse_ages(age_groups_hiv, num_genders),
+            hiv_age_up_prob(age_groups_hiv, num_genders) {}
+
+      void reset() {
+        migration_rate.setZero();
+        hiv_net_migration.setZero();
+        hiv_population_coarse_ages.setZero();
+        hiv_age_up_prob.setZero();
+      }
+    };
   }
-};
+}

--- a/inst/include/types.hpp
+++ b/inst/include/types.hpp
@@ -12,7 +12,7 @@ using TensorMap2 = Eigen::TensorMap <Eigen::Tensor<real_type, 2>>;
 
 template<typename real_type>
 using TensorMap3 = Eigen::TensorMap <Eigen::Tensor<real_type, 3>>;
- 
+
 template<typename real_type>
 using Tensor2 = Eigen::Tensor<real_type, 2>;
 
@@ -71,6 +71,7 @@ struct State {
 };
 
 namespace internal {
+
 const int MALE = 0;
 const int FEMALE = 1;
 
@@ -94,5 +95,6 @@ struct IntermediateData {
     hiv_age_up_prob.setZero();
   }
 };
+
 }
 }

--- a/inst/include/types.hpp
+++ b/inst/include/types.hpp
@@ -4,95 +4,95 @@
 
 namespace leapfrog {
 
-  template<typename real_type>
-  using TensorMap1 = Eigen::TensorMap <Eigen::Tensor<real_type, 1>>;
+template<typename real_type>
+using TensorMap1 = Eigen::TensorMap <Eigen::Tensor<real_type, 1>>;
 
-  template<typename real_type>
-  using TensorMap2 = Eigen::TensorMap <Eigen::Tensor<real_type, 2>>;
+template<typename real_type>
+using TensorMap2 = Eigen::TensorMap <Eigen::Tensor<real_type, 2>>;
 
-  template<typename real_type>
-  using TensorMap3 = Eigen::TensorMap <Eigen::Tensor<real_type, 3>>;
+template<typename real_type>
+using TensorMap3 = Eigen::TensorMap <Eigen::Tensor<real_type, 3>>;
+ 
+template<typename real_type>
+using Tensor2 = Eigen::Tensor<real_type, 2>;
 
-  template<typename real_type>
-  using Tensor2 = Eigen::Tensor<real_type, 2>;
+template<typename real_type>
+using Tensor3 = Eigen::Tensor<real_type, 3>;
 
-  template<typename real_type>
-  using Tensor3 = Eigen::Tensor<real_type, 3>;
+template<typename real_type>
+using Tensor4 = Eigen::Tensor<real_type, 4>;
 
-  template<typename real_type>
-  using Tensor4 = Eigen::Tensor<real_type, 4>;
+template<typename real_type>
+struct Parameters {
+  int num_genders;
+  int age_groups_pop;             // Default 81 for ages 0 to 80+
+  int fertility_first_age_group;  // First index of population eligible for
+  // fertility
+  int age_groups_fert;            // Number of ages eligible for fertility
+  int age_groups_hiv;             // Numer of age groups in HIV population
+  int disease_stages;             // Number of HIV disease stages
+  int hiv_adult_first_age_group;  // First index of HIV population to model as
+  // adult
+  int treatment_stages;           // Number of HIV ART treatment stages
+  int time_art_start;             // Time step to start ART treatment
+  TensorMap1<int> age_groups_hiv_span;  // Number of years in each HIV age group
 
-  template<typename real_type>
-  struct Parameters {
-    int num_genders;
-    int age_groups_pop;             // Default 81 for ages 0 to 80+
-    int fertility_first_age_group;  // First index of population eligible for
-    // fertility
-    int age_groups_fert;            // Number of ages eligible for fertility
-    int age_groups_hiv;             // Numer of age groups in HIV population
-    int disease_stages;             // Number of HIV disease stages
-    int hiv_adult_first_age_group;  // First index of HIV population to model as
-    // adult
-    int treatment_stages;           // Number of HIV ART treatment stages
-    int time_art_start;             // Time step to start ART treatment
-    TensorMap1<int> age_groups_hiv_span;  // Number of years in each HIV age group
+  TensorMap2<real_type> base_pop;
+  TensorMap3<real_type> survival;
+  TensorMap3<real_type> net_migration;
+  TensorMap2<real_type> age_sex_fertility_ratio;
+  TensorMap2<real_type> births_sex_prop;
+};
 
-    TensorMap2<real_type> base_pop;
-    TensorMap3<real_type> survival;
-    TensorMap3<real_type> net_migration;
-    TensorMap2<real_type> age_sex_fertility_ratio;
-    TensorMap2<real_type> births_sex_prop;
-  };
+template<typename real_type>
+struct State {
+  Tensor2<real_type> total_population;
+  Tensor2<real_type> natural_deaths;
+  Tensor2<real_type> hiv_population;
+  Tensor2<real_type> hiv_natural_deaths;
+  Tensor3<real_type> hiv_strat_adult;
+  Tensor4<real_type> art_strat_adult;
+  real_type births;
 
-  template<typename real_type>
-  struct State {
-    Tensor2<real_type> total_population;
-    Tensor2<real_type> natural_deaths;
-    Tensor2<real_type> hiv_population;
-    Tensor2<real_type> hiv_natural_deaths;
-    Tensor3<real_type> hiv_strat_adult;
-    Tensor4<real_type> art_strat_adult;
-    real_type births;
+  State(int age_groups_pop,
+        int num_genders,
+        int disease_stages,
+        int age_groups_hiv,
+        int treatment_stages)
+      : total_population(age_groups_pop, num_genders),
+        natural_deaths(age_groups_pop, num_genders),
+        hiv_population(age_groups_pop, num_genders),
+        hiv_natural_deaths(age_groups_pop, num_genders),
+        hiv_strat_adult(disease_stages, age_groups_hiv, num_genders),
+        art_strat_adult(treatment_stages,
+                        disease_stages,
+                        age_groups_hiv,
+                        num_genders) {}
+};
 
-    State(int age_groups_pop,
-          int num_genders,
-          int disease_stages,
-          int age_groups_hiv,
-          int treatment_stages)
-        : total_population(age_groups_pop, num_genders),
-          natural_deaths(age_groups_pop, num_genders),
-          hiv_population(age_groups_pop, num_genders),
-          hiv_natural_deaths(age_groups_pop, num_genders),
-          hiv_strat_adult(disease_stages, age_groups_hiv, num_genders),
-          art_strat_adult(treatment_stages,
-                          disease_stages,
-                          age_groups_hiv,
-                          num_genders) {}
-  };
+namespace internal {
+const int MALE = 0;
+const int FEMALE = 1;
 
-  namespace internal {
-    const int MALE = 0;
-    const int FEMALE = 1;
+template<typename real_type>
+struct IntermediateData {
+  Tensor2<real_type> migration_rate;
+  Tensor2<real_type> hiv_net_migration;
+  Tensor2<real_type> hiv_population_coarse_ages;
+  Tensor2<real_type> hiv_age_up_prob;
 
-    template<typename real_type>
-    struct IntermediateData {
-      Tensor2<real_type> migration_rate;
-      Tensor2<real_type> hiv_net_migration;
-      Tensor2<real_type> hiv_population_coarse_ages;
-      Tensor2<real_type> hiv_age_up_prob;
+  IntermediateData(int age_groups_pop, int age_groups_hiv, int num_genders)
+      : migration_rate(age_groups_pop, num_genders),
+        hiv_net_migration(age_groups_pop, num_genders),
+        hiv_population_coarse_ages(age_groups_hiv, num_genders),
+        hiv_age_up_prob(age_groups_hiv, num_genders) {}
 
-      IntermediateData(int age_groups_pop, int age_groups_hiv, int num_genders)
-          : migration_rate(age_groups_pop, num_genders),
-            hiv_net_migration(age_groups_pop, num_genders),
-            hiv_population_coarse_ages(age_groups_hiv, num_genders),
-            hiv_age_up_prob(age_groups_hiv, num_genders) {}
-
-      void reset() {
-        migration_rate.setZero();
-        hiv_net_migration.setZero();
-        hiv_population_coarse_ages.setZero();
-        hiv_age_up_prob.setZero();
-      }
-    };
+  void reset() {
+    migration_rate.setZero();
+    hiv_net_migration.setZero();
+    hiv_population_coarse_ages.setZero();
+    hiv_age_up_prob.setZero();
   }
+};
+}
 }

--- a/src/frogger.cpp
+++ b/src/frogger.cpp
@@ -21,8 +21,8 @@ int get_simulation_years(const Rcpp::List demp, SEXP r_sim_years) {
   return sim_years;
 }
 
-TensorMap1<int> get_age_groups_hiv_span(const Rcpp::List projection_parameters,
-                                        std::string hiv_age_stratification) {
+leapfrog::TensorMap1<int> get_age_groups_hiv_span(const Rcpp::List projection_parameters,
+                                                  std::string hiv_age_stratification) {
   int age_groups_hiv;
   SEXP data;
   if (hiv_age_stratification == "full") {
@@ -40,7 +40,7 @@ TensorMap1<int> get_age_groups_hiv_span(const Rcpp::List projection_parameters,
     Rcpp::stop("Invalid size of data, expected %d got %d", age_groups_hiv,
                LENGTH(data));
   }
-  TensorMap1<int> age_groups_hiv_span(INTEGER(data), age_groups_hiv);
+  leapfrog::TensorMap1<int> age_groups_hiv_span(INTEGER(data), age_groups_hiv);
   return age_groups_hiv_span;
 }
 
@@ -64,37 +64,37 @@ Rcpp::List run_base_model(const Rcpp::List data,
       get_age_groups_hiv_span(projection_parameters, hiv_age_stratification);
   int age_groups_hiv = static_cast<int>(age_groups_hiv_span.size());
 
-  TensorMap2<double> base_pop(REAL(data["basepop"]), age_groups_pop,
+  leapfrog::TensorMap2<double> base_pop(REAL(data["basepop"]), age_groups_pop,
                               num_genders);
   // Survival has size age_groups_pop + 1 as this is the probability of
   // surviving between ages, so from 0 to 1, 1 to 2, ..., 79 to 80+ and
   // 80+ to 80+
-  TensorMap3<double> survival(REAL(data["Sx"]), age_groups_pop + 1, num_genders,
-                              proj_years);
-  TensorMap3<double> net_migration(REAL(data["netmigr_adj"]), age_groups_pop,
-                                   num_genders, proj_years);
-  TensorMap2<double> age_sex_fertility_ratio(REAL(data["asfr"]),
-                                             age_groups_fert, proj_years);
-  TensorMap2<double> births_sex_prop(REAL(data["births_sex_prop"]), num_genders,
-                                     proj_years);
+  leapfrog::TensorMap3<double> survival(REAL(data["Sx"]), age_groups_pop + 1, num_genders,
+                                       proj_years);
+  leapfrog::TensorMap3<double> net_migration(REAL(data["netmigr_adj"]), age_groups_pop,
+                                            num_genders, proj_years);
+  leapfrog::TensorMap2<double> age_sex_fertility_ratio(REAL(data["asfr"]),
+                                                      age_groups_fert, proj_years);
+  leapfrog::TensorMap2<double> births_sex_prop(REAL(data["births_sex_prop"]), num_genders,
+                                              proj_years);
 
-  Parameters<double> params = {num_genders,
-                               age_groups_pop,
-                               fertility_first_age_group,
-                               age_groups_fert,
-                               age_groups_hiv,
-                               disease_stages,
-                               hiv_adult_first_age_group,
-                               treatment_stages,
-                               time_art_start,
-                               age_groups_hiv_span,
-                               base_pop,
-                               survival,
-                               net_migration,
-                               age_sex_fertility_ratio,
-                               births_sex_prop};
+  leapfrog::Parameters<double> params = {num_genders,
+                                        age_groups_pop,
+                                        fertility_first_age_group,
+                                        age_groups_fert,
+                                        age_groups_hiv,
+                                        disease_stages,
+                                        hiv_adult_first_age_group,
+                                        treatment_stages,
+                                        time_art_start,
+                                        age_groups_hiv_span,
+                                        base_pop,
+                                        survival,
+                                        net_migration,
+                                        age_sex_fertility_ratio,
+                                        births_sex_prop};
 
-  auto state = run_model(proj_years, params);
+  auto state = leapfrog::run_model(proj_years, params);
 
   Rcpp::NumericVector r_total_population(age_groups_pop * num_genders);
   Rcpp::NumericVector r_births(1);

--- a/src/frogger.cpp
+++ b/src/frogger.cpp
@@ -65,34 +65,34 @@ Rcpp::List run_base_model(const Rcpp::List data,
   int age_groups_hiv = static_cast<int>(age_groups_hiv_span.size());
 
   leapfrog::TensorMap2<double> base_pop(REAL(data["basepop"]), age_groups_pop,
-                              num_genders);
+                                        num_genders);
   // Survival has size age_groups_pop + 1 as this is the probability of
   // surviving between ages, so from 0 to 1, 1 to 2, ..., 79 to 80+ and
   // 80+ to 80+
   leapfrog::TensorMap3<double> survival(REAL(data["Sx"]), age_groups_pop + 1, num_genders,
-                                       proj_years);
+                                        proj_years);
   leapfrog::TensorMap3<double> net_migration(REAL(data["netmigr_adj"]), age_groups_pop,
-                                            num_genders, proj_years);
+                                             num_genders, proj_years);
   leapfrog::TensorMap2<double> age_sex_fertility_ratio(REAL(data["asfr"]),
-                                                      age_groups_fert, proj_years);
+                                                       age_groups_fert, proj_years);
   leapfrog::TensorMap2<double> births_sex_prop(REAL(data["births_sex_prop"]), num_genders,
-                                              proj_years);
+                                               proj_years);
 
   leapfrog::Parameters<double> params = {num_genders,
-                                        age_groups_pop,
-                                        fertility_first_age_group,
-                                        age_groups_fert,
-                                        age_groups_hiv,
-                                        disease_stages,
-                                        hiv_adult_first_age_group,
-                                        treatment_stages,
-                                        time_art_start,
-                                        age_groups_hiv_span,
-                                        base_pop,
-                                        survival,
-                                        net_migration,
-                                        age_sex_fertility_ratio,
-                                        births_sex_prop};
+                                         age_groups_pop,
+                                         fertility_first_age_group,
+                                         age_groups_fert,
+                                         age_groups_hiv,
+                                         disease_stages,
+                                         hiv_adult_first_age_group,
+                                         treatment_stages,
+                                         time_art_start,
+                                         age_groups_hiv_span,
+                                         base_pop,
+                                         survival,
+                                         net_migration,
+                                         age_sex_fertility_ratio,
+                                         births_sex_prop};
 
   auto state = leapfrog::run_model(proj_years, params);
 


### PR DESCRIPTION
This PR is quite noisy but only has minor changes
* Add a top level namespace leapfrog which exports `run_model` function and types `TensorMapN`, `TensorN`, `Parameters` and `State`. And adds everything else to the `leapfrog.internal` namespace. We could split up this internal namespace.