### PR TITLE
Fix issue with base conversion modifying underlying data

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CidrRootsConfiguration">
+    <excludeRoots>
+      <file path="$PROJECT_DIR$/.Rproj.user" />
+    </excludeRoots>
+  </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MakefileSettings">
     <option name="linkedExternalProjectsSettings">

--- a/R/generate_cpp.R
+++ b/R/generate_cpp.R
@@ -190,13 +190,17 @@ generate_input_from_r <- function(inputs) {
     if (input$dims == 1 && dimensions[1] == 1) {
       return(generate_length1_input(input))
     }
-    lhs <- sprintf("  const leapfrog::TensorMap%s<%s> %s",
-                   input$dims, input$type, input$cpp_name)
     rhs <- sprintf("parse_data<%s>(data, \"%s\", %s)",
                    input$type, input$r_name, dimensions)
+    tensor_type <- "leapfrog::TensorMap"
     if (!is.null(input$convert_base) && input$convert_base) {
       rhs <- sprintf("convert_base<%s>(%s)", input$dims, rhs)
+      ## Must be a tensor otherwise the convert_base will
+      ## modify the underlying R data which we do not want to do
+      tensor_type <- "leapfrog::Tensor"
     }
+    lhs <- sprintf("  const %s%s<%s> %s",
+                   tensor_type, input$dims, input$type, input$cpp_name)
     paste0(lhs, " = ", rhs, ";")
   })
 }

--- a/inst/include/model_input.hpp
+++ b/inst/include/model_input.hpp
@@ -27,7 +27,7 @@ leapfrog::Parameters<ModelVariant, real_type> setup_model_params(const Rcpp::Lis
   const leapfrog::TensorMap1<real_type> sex_rate_ratio = parse_data<real_type>(data, "incrr_sex", proj_years);
   const leapfrog::TensorMap3<real_type> cd4_mortality = parse_data<real_type>(data, "cd4_mort", base.hDS, base.hAG, base.NS);
   const leapfrog::TensorMap3<real_type> cd4_progression = parse_data<real_type>(data, "cd4_prog", base.hDS - 1, base.hAG, base.NS);
-  const leapfrog::TensorMap1<int> idx_hm_elig = convert_base<1>(parse_data<int>(data, "artcd4elig_idx", proj_years + 1));
+  const leapfrog::Tensor1<int> idx_hm_elig = convert_base<1>(parse_data<int>(data, "artcd4elig_idx", proj_years + 1));
   const leapfrog::TensorMap3<real_type> cd4_initial_distribution = parse_data<real_type>(data, "cd4_initdist", base.hDS, base.hAG, base.NS);
   const leapfrog::TensorMap4<real_type> mortality = parse_data<real_type>(data, "art_mort", base.hTS, base.hDS, base.hAG, base.NS);
   const leapfrog::TensorMap2<real_type> mortaility_time_rate_ratio = parse_data<real_type>(data, "artmx_timerr", base.hTS, proj_years);

--- a/inst/include/r_utils.hpp
+++ b/inst/include/r_utils.hpp
@@ -54,9 +54,10 @@ auto parse_data(const Rcpp::List data, const std::string& key, Args... dims) {
 
 template<std::size_t rank>
 auto convert_base(Eigen::TensorMap<Eigen::Tensor<int, rank>> map) {
-  for (int i = 0; i < map.size(); ++i) {
+  Eigen::Tensor<int, rank> new_tensor = map; // Create a copy
+  for (int i = 0; i < new_tensor.size(); ++i) {
     // 0-based indexing in C++ vs 1-based indexing in R
-    map.data()[i] = map.data()[i] - 1;
+    new_tensor.data()[i] = new_tensor.data()[i] - 1;
   }
-  return map;
+  return new_tensor;
 }

--- a/tests/testthat/test-frogger.R
+++ b/tests/testthat/test-frogger.R
@@ -182,6 +182,20 @@ test_that("model can be run with ART initiation", {
                           run_child_model = FALSE))
 })
 
+test_that("model can be run twice on the same data", {
+  ## Regression test as we saw the 2nd run failing as the first fit
+  ## was modifying the R stored data causing the 2nd run on the same
+  ## data to read from an index of -1
+  demp <- readRDS(test_path("testdata/demographic_projection_object_adult.rds"))
+  parameters <- readRDS(test_path("testdata/projection_parameters_adult.rds"))
+
+  out <- run_model(demp, parameters, NULL, NULL, 0:60,
+                   run_child_model = FALSE)
+  out2 <- run_model(demp, parameters, NULL, NULL, 0:60,
+                    run_child_model = FALSE)
+  expect_identical(out, out2)
+})
+
 test_that("error thrown if trying to run model for more than max years", {
   demp <- readRDS(test_path("testdata/demographic_projection_object_adult.rds"))
   parameters <- readRDS(test_path("testdata/projection_parameters_adult.rds"))

--- a/tests/testthat/test-generate-cpp.R
+++ b/tests/testthat/test-generate-cpp.R
@@ -35,7 +35,7 @@ test_that("can generate input parsing", {
     "\\(data, \"basepop\", base.pAG, base.NS\\);"),
     result)))
   expect_true(any(grepl(paste0(
-    "const leapfrog::TensorMap1<int> idx_hm_elig = convert_base<1>\\(",
+    "const leapfrog::Tensor1<int> idx_hm_elig = convert_base<1>\\(",
     "parse_data<int>\\(data, \"artcd4elig_idx\", proj_years \\+ 1\\)\\);"),
     result)))
   expect_true(any(grepl(


### PR DESCRIPTION
There was a bug here which I spotted looking at another issue reporter by Maggie. The `convert_base` r-utils function was modifying the underlying R data meaning that the 2nd time we run the fit on the same data it starts reading from uninitialised data. This fixes that by copying the data and modifying the copy