### PR TITLE
Add child model to benchmarking script

### DIFF
--- a/scripts/benchmark
+++ b/scripts/benchmark
@@ -8,7 +8,7 @@ parameters <- readRDS(file.path(root_dir, "tests/testthat/testdata/projection_pa
 message("Benchmarking coarse stratified fit")
 bench::mark(
   leapfrog = leapfrog::leapfrogR(demp, parameters, hiv_strat = "coarse"),
-  frogger = frogger::run_model(demp, parameters, NULL, NULL, 0:60, hiv_age_stratification = "coarse"),
+  frogger = frogger::run_model(demp, parameters, NULL, NULL, 0:60, hiv_age_stratification = "coarse", run_child_model = FALSE),
   iterations = 10,
   check = FALSE
 )
@@ -16,7 +16,17 @@ bench::mark(
 message("Benchmarking full fit")
 bench::mark(
   leapfrog = leapfrog::leapfrogR(demp, parameters, hiv_strat = "full"),
-  frogger = frogger::run_model(demp, parameters, NULL, NULL, 0:60, hiv_age_stratification = "full"),
+  frogger = frogger::run_model(demp, parameters, NULL, NULL, 0:60, hiv_age_stratification = "full", run_child_model = FALSE),
+  iterations = 10,
+  check = FALSE
+)
+
+demp <- readRDS(file.path(root_dir, "tests/testthat/testdata/demographic_projection_object_child.rds"))
+parameters <- readRDS(file.path(root_dir, "tests/testthat/testdata/projection_parameters_child.rds"))
+
+message("Benchmarking child fit")
+bench::mark(
+  frogger = frogger::run_model(demp, parameters, NULL, NULL, 0:60, hiv_age_stratification = "full", run_child_model = TRUE),
   iterations = 10,
   check = FALSE
 )

--- a/scripts/benchmark
+++ b/scripts/benchmark
@@ -5,7 +5,7 @@ root_dir <- here::here()
 demp <- readRDS(file.path(root_dir, "tests/testthat/testdata/demographic_projection_object_adult.rds"))
 parameters <- readRDS(file.path(root_dir, "tests/testthat/testdata/projection_parameters_adult.rds"))
 
-message("Benchmarking coarse stratified fit")
+message("Benchmarking coarse stratified model")
 bench::mark(
   leapfrog = leapfrog::leapfrogR(demp, parameters, hiv_strat = "coarse"),
   frogger = frogger::run_model(demp, parameters, NULL, NULL, 0:60, hiv_age_stratification = "coarse", run_child_model = FALSE),
@@ -13,7 +13,7 @@ bench::mark(
   check = FALSE
 )
 
-message("Benchmarking full fit")
+message("Benchmarking full model")
 bench::mark(
   leapfrog = leapfrog::leapfrogR(demp, parameters, hiv_strat = "full"),
   frogger = frogger::run_model(demp, parameters, NULL, NULL, 0:60, hiv_age_stratification = "full", run_child_model = FALSE),
@@ -24,7 +24,7 @@ bench::mark(
 demp <- readRDS(file.path(root_dir, "tests/testthat/testdata/demographic_projection_object_child.rds"))
 parameters <- readRDS(file.path(root_dir, "tests/testthat/testdata/projection_parameters_child.rds"))
 
-message("Benchmarking child fit")
+message("Benchmarking child model")
 bench::mark(
   frogger = frogger::run_model(demp, parameters, NULL, NULL, 0:60, hiv_age_stratification = "full", run_child_model = TRUE),
   iterations = 10,


### PR DESCRIPTION
Current master getting

```
rashton@wpia-dide270:~/projects/frogger$ ./scripts/benchmark 
Benchmarking coarse stratified model
# A tibble: 2 × 13
  expression      min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time
  <bch:expr> <bch:tm> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm>
1 leapfrog     1.34ms 1.67ms      610.    6.34MB        0    10     0     16.4ms
2 frogger      2.28ms 2.29ms      427.    1.04MB        0    10     0     23.4ms
# ℹ 4 more variables: result <list>, memory <list>, time <list>, gc <list>
Benchmarking full model
# A tibble: 2 × 13
  expression     min  median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time
  <bch:expr> <bch:t> <bch:t>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm>
1 leapfrog    6.46ms  8.13ms     130.     4.33MB     14.4     9     1     69.2ms
2 frogger    10.38ms 10.54ms      91.2    4.33MB     10.1     9     1     98.7ms
# ℹ 4 more variables: result <list>, memory <list>, time <list>, gc <list>
Benchmarking child model
# A tibble: 1 × 13
  expression      min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time
  <bch:expr> <bch:tm> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm>
1 frogger      12.4ms 12.5ms      79.6    5.58MB     8.85     9     1      113ms
# ℹ 4 more variables: result <list>, memory <list>, time <list>, gc <list>
```