### PR TITLE
Improve valgrind CI check

### DIFF
--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -44,7 +44,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
 
       - name: compile package
-        run: R -e 'pkgbuild::compile_dll(quiet = TRUE)'
+        run: R -e 'install.packages("pkgbuild"); pkgbuild::compile_dll(quiet = TRUE)'
 
       - name: valgrind leak check
         run: make test_leaks

--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           extra-packages: |
             any::pkgbuild
-            rlib::withr
+            any::withr
 
       - name: compile package
         run: |

--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -45,9 +45,23 @@ jobs:
         with:
           extra-packages: |
             any::pkgbuild
+            rlib::withr
 
       - name: compile package
-        run: R -e 'pkgbuild::compile_dll(quiet = TRUE)'
+        run: |
+          makevars = paste(
+            "-Wall",
+            "-pedantic",
+            "-Wno-unused-parameter",
+            "-Wno-cast-function-type",
+            "-Wno-missing-field-initializers",
+            "-Wno-ignored-attributes",
+            "-Wno-deprecated-copy"
+          )
+          withr::with_makevars(c(CXXFLAGS = makevars),
+            pkgbuild::compile_dll(quiet = TRUE)
+          )
+        shell: Rscript {0}
 
       - name: valgrind leak check
         run: make test_leaks

--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -42,9 +42,12 @@ jobs:
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::pkgbuild
 
       - name: compile package
-        run: R -e 'install.packages("pkgbuild"); pkgbuild::compile_dll(quiet = TRUE)'
+        run: R -e 'pkgbuild::compile_dll(quiet = TRUE)'
 
       - name: valgrind leak check
         run: make test_leaks

--- a/.github/workflows/valgrind.yaml
+++ b/.github/workflows/valgrind.yaml
@@ -43,5 +43,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
 
+      - name: compile package
+        run: R -e 'pkgbuild::compile_dll(quiet = TRUE)'
+
       - name: valgrind leak check
         run: make test_leaks

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ README.md: README.Rmd
 	rm -f $@.bak
 
 test_leaks:
-	R -d 'valgrind --leak-check=full' -e 'testthat::test_local(".")'
+	R -d 'valgrind --leak-check=full --error-exitcode=1' -e 'testthat::test_local(".")'
 
 check:
 	_R_CHECK_CRAN_INCOMING_=FALSE make check_all

--- a/inst/include/child_model_simulation.hpp
+++ b/inst/include/child_model_simulation.hpp
@@ -169,13 +169,6 @@ void run_child_hiv_mort(int time_step,
   constexpr auto hc_ss = StateSpace<ModelVariant>().children;
   const auto cpars = pars.children.children;
 
-  if (time_step == 1) {
-    // This will read from uninitialised memory
-    if (intermediate.children.hc_grad(8, hc_ss.hcTT - 1, hc_ss.hc2_agestart - 1, ss.NS - 1) > 0) {
-      std::cout << "It is true!";
-    }
-  }
-
   for (int s = 0; s < ss.NS; ++s) {
     for (int a = 0; a < hc_ss.hc2_agestart; ++a) {
       for (int cat = 0; cat < hc_ss.hcTT; ++cat) {

--- a/inst/include/child_model_simulation.hpp
+++ b/inst/include/child_model_simulation.hpp
@@ -169,6 +169,13 @@ void run_child_hiv_mort(int time_step,
   constexpr auto hc_ss = StateSpace<ModelVariant>().children;
   const auto cpars = pars.children.children;
 
+  if (time_step == 1) {
+    // This will read from uninitialised memory
+    if (intermediate.children.hc_grad(8, hc_ss.hcTT - 1, hc_ss.hc2_agestart - 1, ss.NS - 1) > 0) {
+      std::cout << "It is true!"
+    }
+  }
+
   for (int s = 0; s < ss.NS; ++s) {
     for (int a = 0; a < hc_ss.hc2_agestart; ++a) {
       for (int cat = 0; cat < hc_ss.hcTT; ++cat) {

--- a/inst/include/child_model_simulation.hpp
+++ b/inst/include/child_model_simulation.hpp
@@ -172,7 +172,7 @@ void run_child_hiv_mort(int time_step,
   if (time_step == 1) {
     // This will read from uninitialised memory
     if (intermediate.children.hc_grad(8, hc_ss.hcTT - 1, hc_ss.hc2_agestart - 1, ss.NS - 1) > 0) {
-      std::cout << "It is true!"
+      std::cout << "It is true!";
     }
   }
 


### PR DESCRIPTION
Trying to fix up a few valgrind CI issues, namely
* pkgbuild not available on CI
* Build is not failing when there are valgrind errors, was missing a `--error-exitcode=1` to valgrind, previous failure was exiting because of a segfault but could be memory violations which don't cause it to outright fail
* Really noisy when compilation failure, setting some makevars