### PR TITLE
Ensure state types can be passed by reference

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [ main, master ]
   pull_request:
-    branches: [ main, master ]
 
 name: R-CMD-check
 

--- a/.github/workflows/leapfrog-py-test.yaml
+++ b/.github/workflows/leapfrog-py-test.yaml
@@ -2,13 +2,7 @@ name: Test
 
 on:
   pull_request:
-    branches:
-      - main
-      - python-interface-poc
   push:
-    branches:
-      - main
-      - python-interface-poc
 
 jobs:
   run:

--- a/inst/include/child_model_simulation.hpp
+++ b/inst/include/child_model_simulation.hpp
@@ -7,11 +7,11 @@ namespace leapfrog {
 
 namespace internal {
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_child_ageing(int time_step,
                       const Parameters<ModelVariant, real_type> &pars,
-                      const State<ModelVariant, real_type> &state_curr,
-                      State<ModelVariant, real_type> &state_next,
+                      const State<ModelVariant, real_type, OwnedData> &state_curr,
+                      State<ModelVariant, real_type, OwnedData> &state_next,
                       IntermediateData<ModelVariant, real_type> &intermediate) {
   const auto demog = pars.base.demography;
   const auto cpars = pars.children.children;
@@ -67,11 +67,11 @@ void run_child_ageing(int time_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_wlhiv_births(int time_step,
                       const Parameters<ModelVariant, real_type> &pars,
-                      const State<ModelVariant, real_type> &state_curr,
-                      State<ModelVariant, real_type> &state_next,
+                      const State<ModelVariant, real_type, OwnedData> &state_curr,
+                      State<ModelVariant, real_type, OwnedData> &state_next,
                       IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "run_wlhiv_births can only be called for model variants where run_child_model is true");
@@ -84,7 +84,8 @@ void run_wlhiv_births(int time_step,
     intermediate.children.asfr_sum += demog.age_specific_fertility_rate(a, time_step);
   } // end a
 
-  intermediate.children.births_sum = state_next.base.births;
+  // Births is always length 1
+  intermediate.children.births_sum = state_next.base.births(0);
 
   for (int a = 0; a < pars.base.options.p_fertility_age_groups; ++a) {
     intermediate.children.nHIVcurr = 0.0;
@@ -137,11 +138,11 @@ void run_wlhiv_births(int time_step,
   state_next.children.hiv_births = intermediate.children.birthsHE;
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_wlhiv_births_input_mat_prev(int time_step,
                                      const Parameters<ModelVariant, real_type> &pars,
-                                     const State<ModelVariant, real_type> &state_curr,
-                                     State<ModelVariant, real_type> &state_next,
+                                     const State<ModelVariant, real_type, OwnedData> &state_curr,
+                                     State<ModelVariant, real_type, OwnedData> &state_next,
                                      IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "run_wlhiv_births_input_mat_prev can only be called for model variants where run_child_model is true");
@@ -150,11 +151,11 @@ void run_wlhiv_births_input_mat_prev(int time_step,
   state_next.children.hiv_births = cpars.mat_hiv_births(time_step);
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void calc_hiv_negative_pop(int time_step,
                            const Parameters<ModelVariant, real_type> &pars,
-                           const State<ModelVariant, real_type> &state_curr,
-                           State<ModelVariant, real_type> &state_next,
+                           const State<ModelVariant, real_type, OwnedData> &state_curr,
+                           State<ModelVariant, real_type, OwnedData> &state_next,
                            IntermediateData<ModelVariant, real_type> &intermediate) {
   const auto demog = pars.base.demography;
   const auto cpars = pars.children.children;
@@ -169,11 +170,11 @@ void calc_hiv_negative_pop(int time_step,
   }//end s
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void convert_PMTCT_num_to_perc(int time_step,
                                const Parameters<ModelVariant, real_type> &pars,
-                               const State<ModelVariant, real_type> &state_curr,
-                               State<ModelVariant, real_type> &state_next,
+                               const State<ModelVariant, real_type, OwnedData> &state_curr,
+                               State<ModelVariant, real_type, OwnedData> &state_next,
                                IntermediateData<ModelVariant, real_type> &intermediate) {
   const auto cpars = pars.children.children;
   static_assert(ModelVariant::run_child_model,
@@ -210,11 +211,11 @@ void convert_PMTCT_num_to_perc(int time_step,
   intermediate.children.PMTCT_coverage(5) = intermediate.children.PMTCT_coverage(5) * cpars.PMTCT_dropout(1,time_step);
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void convert_PMTCT_pre_bf(int time_step,
                           const Parameters<ModelVariant, real_type> &pars,
-                          const State<ModelVariant, real_type> &state_curr,
-                          State<ModelVariant, real_type> &state_next,
+                          const State<ModelVariant, real_type, OwnedData> &state_curr,
+                          State<ModelVariant, real_type, OwnedData> &state_next,
                           IntermediateData<ModelVariant, real_type> &intermediate) {
   const auto cpars = pars.children.children;
   static_assert(ModelVariant::run_child_model,
@@ -227,11 +228,11 @@ void convert_PMTCT_pre_bf(int time_step,
   } //end hPS
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void calc_wlhiv_cd4_proportion(int time_step,
                                const Parameters<ModelVariant, real_type> &pars,
-                               const State<ModelVariant, real_type> &state_curr,
-                               State<ModelVariant, real_type> &state_next,
+                               const State<ModelVariant, real_type, OwnedData> &state_curr,
+                               State<ModelVariant, real_type, OwnedData> &state_next,
                                IntermediateData<ModelVariant, real_type> &intermediate) {
   const auto cpars = pars.children.children;
   static_assert(ModelVariant::run_child_model,
@@ -277,11 +278,11 @@ void calc_wlhiv_cd4_proportion(int time_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void adjust_optAB_transmission_rate(int time_step,
                                     const Parameters<ModelVariant, real_type> &pars,
-                                    const State<ModelVariant, real_type> &state_curr,
-                                    State<ModelVariant, real_type> &state_next,
+                                    const State<ModelVariant, real_type, OwnedData> &state_curr,
+                                    State<ModelVariant, real_type, OwnedData> &state_next,
                                     IntermediateData<ModelVariant, real_type> &intermediate) {
   const auto cpars = pars.children.children;
   static_assert(ModelVariant::run_child_model,
@@ -308,11 +309,11 @@ void adjust_optAB_transmission_rate(int time_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void adjust_optAB_bf_transmission_rate(int time_step,
                                        const Parameters<ModelVariant, real_type> &pars,
-                                       const State<ModelVariant, real_type> &state_curr,
-                                       State<ModelVariant, real_type> &state_next,
+                                       const State<ModelVariant, real_type, OwnedData> &state_curr,
+                                       State<ModelVariant, real_type, OwnedData> &state_next,
                                        IntermediateData<ModelVariant, real_type> &intermediate) {
   const auto cpars = pars.children.children;
   static_assert(ModelVariant::run_child_model,
@@ -339,11 +340,11 @@ void adjust_optAB_bf_transmission_rate(int time_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_calculate_perinatal_transmission_rate(int time_step,
                                                const Parameters<ModelVariant, real_type> &pars,
-                                               const State<ModelVariant, real_type> &state_curr,
-                                               State<ModelVariant, real_type> &state_next,
+                                               const State<ModelVariant, real_type, OwnedData> &state_curr,
+                                               State<ModelVariant, real_type, OwnedData> &state_next,
                                                IntermediateData<ModelVariant, real_type> &intermediate) {
   const auto demog = pars.base.demography;
   const auto cpars = pars.children.children;
@@ -408,11 +409,11 @@ void run_calculate_perinatal_transmission_rate(int time_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_calculate_transmission_from_incidence_during_breastfeeding(int time_step,
                                                                     const Parameters<ModelVariant, real_type> &pars,
-                                                                    const State<ModelVariant, real_type> &state_curr,
-                                                                    State<ModelVariant, real_type> &state_next,
+                                                                    const State<ModelVariant, real_type, OwnedData> &state_curr,
+                                                                    State<ModelVariant, real_type, OwnedData> &state_next,
                                                                     IntermediateData<ModelVariant, real_type> &intermediate) {
   const auto cpars = pars.children.children;
   static_assert(ModelVariant::run_child_model,
@@ -425,11 +426,11 @@ void run_calculate_transmission_from_incidence_during_breastfeeding(int time_ste
    intermediate.children.bf_incident_hiv_transmission_rate = intermediate.children.bf_at_risk * cpars.vertical_transmission_rate(7,1);
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_bf_transmission_rate(int time_step,
                               const Parameters<ModelVariant, real_type> &pars,
-                              const State<ModelVariant, real_type> &state_curr,
-                              State<ModelVariant, real_type> &state_next,
+                              const State<ModelVariant, real_type, OwnedData> &state_curr,
+                              State<ModelVariant, real_type, OwnedData> &state_next,
                               IntermediateData<ModelVariant, real_type> &intermediate,
                               int bf_start, int bf_end, int index) {
   const auto cpars = pars.children.children;
@@ -536,11 +537,11 @@ void run_bf_transmission_rate(int time_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_nosocomial_infections(int time_step,
                                const Parameters<ModelVariant, real_type> &pars,
-                               const State<ModelVariant, real_type> &state_curr,
-                               State<ModelVariant, real_type> &state_next,
+                               const State<ModelVariant, real_type, OwnedData> &state_curr,
+                               State<ModelVariant, real_type, OwnedData> &state_next,
                                IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss = StateSpace<ModelVariant>().base;
   constexpr auto hc_ss = StateSpace<ModelVariant>().children;
@@ -565,11 +566,11 @@ void run_nosocomial_infections(int time_step,
   } // end NS
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_child_hiv_infections(int time_step,
                               const Parameters<ModelVariant, real_type> &pars,
-                              const State<ModelVariant, real_type> &state_curr,
-                              State<ModelVariant, real_type> &state_next,
+                              const State<ModelVariant, real_type, OwnedData> &state_curr,
+                              State<ModelVariant, real_type, OwnedData> &state_next,
                               IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "run_hiv_child_infections can only be called for model variants where run_child_model is true");
@@ -644,11 +645,11 @@ void run_child_hiv_infections(int time_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void calc_need_for_ctx(int time_step,
                        const Parameters<ModelVariant, real_type> &pars,
-                       const State<ModelVariant, real_type> &state_curr,
-                       State<ModelVariant, real_type> &state_next,
+                       const State<ModelVariant, real_type, OwnedData> &state_curr,
+                       State<ModelVariant, real_type, OwnedData> &state_next,
                        IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "calc_need_for_ctx can only be called for model variants where run_child_model is true");
@@ -706,11 +707,11 @@ void calc_need_for_ctx(int time_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void ctx_need_cov(int time_step,
                   const Parameters<ModelVariant, real_type> &pars,
-                  const State<ModelVariant, real_type> &state_curr,
-                  State<ModelVariant, real_type> &state_next,
+                  const State<ModelVariant, real_type, OwnedData> &state_curr,
+                  State<ModelVariant, real_type, OwnedData> &state_next,
                   IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "ctx_need_cov can only be called for model variants where run_child_model is true");
@@ -733,11 +734,11 @@ void ctx_need_cov(int time_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_child_natural_history(int time_step,
                                const Parameters<ModelVariant, real_type> &pars,
-                               const State<ModelVariant, real_type> &state_curr,
-                               State<ModelVariant, real_type> &state_next,
+                               const State<ModelVariant, real_type, OwnedData> &state_curr,
+                               State<ModelVariant, real_type, OwnedData> &state_next,
                                IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "run_child_natural_history can only be called for model variants where run_child_model is true");
@@ -793,11 +794,11 @@ void run_child_natural_history(int time_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_child_hiv_mort(int time_step,
                         const Parameters<ModelVariant, real_type> &pars,
-                        const State<ModelVariant, real_type> &state_curr,
-                        State<ModelVariant, real_type> &state_next,
+                        const State<ModelVariant, real_type, OwnedData> &state_curr,
+                        State<ModelVariant, real_type, OwnedData> &state_next,
                         IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "run_child_hiv_mort can only be called for model variants where run_child_model is true");
@@ -833,11 +834,11 @@ void run_child_hiv_mort(int time_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void add_child_grad(int time_step,
                     const Parameters<ModelVariant, real_type> &pars,
-                    const State<ModelVariant, real_type> &state_curr,
-                    State<ModelVariant, real_type> &state_next,
+                    const State<ModelVariant, real_type, OwnedData> &state_curr,
+                    State<ModelVariant, real_type, OwnedData> &state_next,
                     IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "add_child_grad can only be called for model variants where run_child_model is true");
@@ -866,11 +867,11 @@ void add_child_grad(int time_step,
   }// end s
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void hc_initiate_art_by_age(int time_step,
                             const Parameters<ModelVariant, real_type> &pars,
-                            const State<ModelVariant, real_type> &state_curr,
-                            State<ModelVariant, real_type> &state_next,
+                            const State<ModelVariant, real_type, OwnedData> &state_curr,
+                            State<ModelVariant, real_type, OwnedData> &state_next,
                             IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "hc_initiate_art_by_age can only be called for model variants where run_child_model is true");
@@ -894,11 +895,11 @@ void hc_initiate_art_by_age(int time_step,
   } // end ss.NS
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void hc_initiate_art_by_cd4(int time_step,
                             const Parameters<ModelVariant, real_type> &pars,
-                            const State<ModelVariant, real_type> &state_curr,
-                            State<ModelVariant, real_type> &state_next,
+                            const State<ModelVariant, real_type, OwnedData> &state_curr,
+                            State<ModelVariant, real_type, OwnedData> &state_next,
                             IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "hc_initiate_art_by_cd4 can only be called for model variants where run_child_model is true");
@@ -924,11 +925,11 @@ void hc_initiate_art_by_cd4(int time_step,
   } // end ss.NS
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void eligible_for_treatment(int time_step,
                             const Parameters<ModelVariant, real_type> &pars,
-                            const State<ModelVariant, real_type> &state_curr,
-                            State<ModelVariant, real_type> &state_next,
+                            const State<ModelVariant, real_type, OwnedData> &state_curr,
+                            State<ModelVariant, real_type, OwnedData> &state_next,
                             IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "eligible_for_treatment can only be called for model variants where run_child_model is true");
@@ -949,11 +950,11 @@ void eligible_for_treatment(int time_step,
   } // end ss.NS
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void on_art_mortality(int time_step,
                      const Parameters<ModelVariant, real_type> &pars,
-                     const State<ModelVariant, real_type> &state_curr,
-                     State<ModelVariant, real_type> &state_next,
+                     const State<ModelVariant, real_type, OwnedData> &state_curr,
+                     State<ModelVariant, real_type, OwnedData> &state_next,
                      IntermediateData<ModelVariant, real_type> &intermediate,
                      int time_art_idx) {
   static_assert(ModelVariant::run_child_model,
@@ -1002,11 +1003,11 @@ void on_art_mortality(int time_step,
   }// end ss.NS
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void deaths_this_year(int time_step,
                       const Parameters<ModelVariant, real_type> &pars,
-                      const State<ModelVariant, real_type> &state_curr,
-                      State<ModelVariant, real_type> &state_next,
+                      const State<ModelVariant, real_type, OwnedData> &state_curr,
+                      State<ModelVariant, real_type, OwnedData> &state_next,
                       IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "deaths_this_year can only be called for model variants where run_child_model is true");
@@ -1032,11 +1033,11 @@ void deaths_this_year(int time_step,
   intermediate.children.hc_art_deaths(0) =  intermediate.children.hc_art_deaths(1) +  intermediate.children.hc_art_deaths(2) + intermediate.children.hc_art_deaths(3);
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void progress_time_on_art(int time_step,
                           const Parameters<ModelVariant, real_type> &pars,
-                          const State<ModelVariant, real_type> &state_curr,
-                          State<ModelVariant, real_type> &state_next,
+                          const State<ModelVariant, real_type, OwnedData> &state_curr,
+                          State<ModelVariant, real_type, OwnedData> &state_next,
                           IntermediateData<ModelVariant, real_type> &intermediate,
                           int current_time_idx, int end_time_idx) {
   static_assert(ModelVariant::run_child_model,
@@ -1062,11 +1063,11 @@ void progress_time_on_art(int time_step,
   }// end hc_ss.hc1DS
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void calc_total_and_unmet_need(int time_step,
                                const Parameters<ModelVariant, real_type> &pars,
-                               const State<ModelVariant, real_type> &state_curr,
-                               State<ModelVariant, real_type> &state_next,
+                               const State<ModelVariant, real_type, OwnedData> &state_curr,
+                               State<ModelVariant, real_type, OwnedData> &state_next,
                                IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "calc_total_and_unmet_need can only be called for model variants where run_child_model is true");
@@ -1109,11 +1110,11 @@ void calc_total_and_unmet_need(int time_step,
   intermediate.children.total_need(0) = intermediate.children.on_art(0) + intermediate.children.unmet_need(0) + intermediate.children.hc_art_deaths(0);
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void calc_age_specific_last_year(int time_step,
                                const Parameters<ModelVariant, real_type> &pars,
-                               const State<ModelVariant, real_type> &state_curr,
-                               State<ModelVariant, real_type> &state_next,
+                               const State<ModelVariant, real_type, OwnedData> &state_curr,
+                               State<ModelVariant, real_type, OwnedData> &state_next,
                                IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "calc_age_specific_last_year can only be called for model variants where run_child_model is true");
@@ -1157,11 +1158,11 @@ void calc_age_specific_last_year(int time_step,
 }
 
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void calc_art_last_year(int time_step,
                         const Parameters<ModelVariant, real_type> &pars,
-                        const State<ModelVariant, real_type> &state_curr,
-                        State<ModelVariant, real_type> &state_next,
+                        const State<ModelVariant, real_type, OwnedData> &state_curr,
+                        State<ModelVariant, real_type, OwnedData> &state_next,
                         IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "calc_art_last_year can only be called for model variants where run_child_model is true");
@@ -1188,11 +1189,11 @@ void calc_art_last_year(int time_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void calc_art_this_year(int time_step,
                         const Parameters<ModelVariant, real_type> &pars,
-                        const State<ModelVariant, real_type> &state_curr,
-                        State<ModelVariant, real_type> &state_next,
+                        const State<ModelVariant, real_type, OwnedData> &state_curr,
+                        State<ModelVariant, real_type, OwnedData> &state_next,
                         IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "calc_art_this_year can only be called for model variants where run_child_model is true");
@@ -1209,11 +1210,11 @@ void calc_art_this_year(int time_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void calc_art_initiates(int time_step,
                         const Parameters<ModelVariant, real_type> &pars,
-                        const State<ModelVariant, real_type> &state_curr,
-                        State<ModelVariant, real_type> &state_next,
+                        const State<ModelVariant, real_type, OwnedData> &state_curr,
+                        State<ModelVariant, real_type, OwnedData> &state_next,
                         IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "calc_art_initiates can only be called for model variants where run_child_model is true");
@@ -1245,11 +1246,11 @@ void calc_art_initiates(int time_step,
 }
 
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void hc_art_initiation_by_age(int time_step,
                               const Parameters<ModelVariant, real_type> &pars,
-                              const State<ModelVariant, real_type> &state_curr,
-                              State<ModelVariant, real_type> &state_next,
+                              const State<ModelVariant, real_type, OwnedData> &state_curr,
+                              State<ModelVariant, real_type, OwnedData> &state_next,
                               IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "hc_art_initiation_by_age can only be called for model variants where run_child_model is true");
@@ -1360,11 +1361,11 @@ void hc_art_initiation_by_age(int time_step,
   }// end if
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void fill_model_outputs(int time_step,
                         const Parameters<ModelVariant, real_type> &pars,
-                        const State<ModelVariant, real_type> &state_curr,
-                        State<ModelVariant, real_type> &state_next,
+                        const State<ModelVariant, real_type, OwnedData> &state_curr,
+                        State<ModelVariant, real_type, OwnedData> &state_next,
                         IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "fill_model_outputs can only be called for model variants where run_child_model is true");
@@ -1398,11 +1399,11 @@ void fill_model_outputs(int time_step,
 
 }// namespace internal
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_child_model_simulation(int time_step,
                                 const Parameters<ModelVariant, real_type> &pars,
-                                const State<ModelVariant, real_type> &state_curr,
-                                State<ModelVariant, real_type> &state_next,
+                                const State<ModelVariant, real_type, OwnedData> &state_curr,
+                                State<ModelVariant, real_type, OwnedData> &state_next,
                                 internal::IntermediateData<ModelVariant, real_type> &intermediate) {
   const auto cpars = pars.children.children;
 

--- a/inst/include/frogger.hpp
+++ b/inst/include/frogger.hpp
@@ -12,8 +12,8 @@ namespace leapfrog {
 
 // If we want to set any state for first iteration to something
 // other than 0 do it here.
-template<typename ModelVariant, typename real_type>
-void set_initial_state(State<ModelVariant, real_type> &state,
+template<typename ModelVariant, typename real_type, bool OwnedData>
+void set_initial_state(State<ModelVariant, real_type, OwnedData> &state,
                        const Parameters<ModelVariant, real_type> &pars) {
   constexpr auto ss = StateSpace<ModelVariant>().base;
   for (int g = 0; g < ss.NS; ++g) {
@@ -37,9 +37,9 @@ template<typename ModelVariant, typename real_type>
 OutputState<ModelVariant, real_type> run_model(int time_steps,
                                                std::vector<int> save_steps,
                                                const Parameters<ModelVariant, real_type> &pars) {
-  auto state = State<ModelVariant, real_type>(pars);
+  auto state = State<ModelVariant, real_type, true>(pars);
   auto state_next = state;
-  set_initial_state<ModelVariant, real_type>(state, pars);
+  set_initial_state<ModelVariant, real_type, true>(state, pars);
 
   internal::IntermediateData<ModelVariant, real_type> intermediate(pars.base.options.hAG_15plus);
 

--- a/inst/include/generated/state_saver_types.hpp
+++ b/inst/include/generated/state_saver_types.hpp
@@ -29,7 +29,7 @@ struct BaseModelOutputState {
   Tensor4<real_type> h_art_initiation;
   Tensor3<real_type> p_hiv_deaths;
 
-  BaseModelOutputState(int output_years): 
+  BaseModelOutputState(int output_years):
     p_total_pop(
       StateSpace<ModelVariant>().base.pAG,
       StateSpace<ModelVariant>().base.NS,
@@ -127,7 +127,7 @@ struct ChildModelOutputState<ChildModel, real_type> {
   Tensor1<real_type> ctx_need;
   Tensor1<real_type> ctx_mean;
 
-  ChildModelOutputState(int output_years): 
+  ChildModelOutputState(int output_years):
     hc1_hiv_pop(
       StateSpace<ChildModel>().children.hc1DS,
       StateSpace<ChildModel>().children.hcTT,
@@ -231,7 +231,7 @@ struct ChildModelStateSaver {
 public:
   void save_state(ChildModelOutputState<ModelVariant, real_type> &full_state,
                   const size_t i,
-                  const State<ModelVariant, real_type> &state) {}
+                  const State<ModelVariant, real_type, true> &state) {}
 };
 
 template<typename ModelVariant, typename real_type>
@@ -239,9 +239,9 @@ struct BaseModelStateSaver {
 public:
   void save_state(BaseModelOutputState<ModelVariant, real_type> &output_state,
                   const size_t i,
-                  const State<ModelVariant, real_type> &state) {
+                  const State<ModelVariant, real_type, true> &state) {
     output_state.p_total_pop.chip(i, output_state.p_total_pop.NumDimensions - 1) = state.base.p_total_pop;
-    output_state.births(i) = state.base.births;
+    output_state.births(i) = state.base.births(0);
     output_state.p_total_pop_natural_deaths.chip(i, output_state.p_total_pop_natural_deaths.NumDimensions - 1) = state.base.p_total_pop_natural_deaths;
     output_state.p_hiv_pop.chip(i, output_state.p_hiv_pop.NumDimensions - 1) = state.base.p_hiv_pop;
     output_state.p_hiv_pop_natural_deaths.chip(i, output_state.p_hiv_pop_natural_deaths.NumDimensions - 1) = state.base.p_hiv_pop_natural_deaths;
@@ -261,7 +261,7 @@ struct ChildModelStateSaver<ChildModel, real_type> {
 public:
   void save_state(ChildModelOutputState<ChildModel, real_type> &output_state,
                   const size_t i,
-                  const State<ChildModel, real_type> &state) {
+                  const State<ChildModel, real_type, true> &state) {
     output_state.hc1_hiv_pop.chip(i, output_state.hc1_hiv_pop.NumDimensions - 1) = state.children.hc1_hiv_pop;
     output_state.hc2_hiv_pop.chip(i, output_state.hc2_hiv_pop.NumDimensions - 1) = state.children.hc2_hiv_pop;
     output_state.hc1_art_pop.chip(i, output_state.hc1_art_pop.NumDimensions - 1) = state.children.hc1_art_pop;

--- a/inst/include/generated/state_types.hpp
+++ b/inst/include/generated/state_types.hpp
@@ -13,48 +13,69 @@ namespace leapfrog {
 
 namespace {
 using Eigen::Sizes;
-using Eigen::TensorFixedSize;
 }
 
-template<typename ModelVariant, typename real_type>
+// In State we want to be able to able to choose between the State object
+// owning the data or it to be a reference to data owned elsewhere.
+template<typename T, typename Sizes, bool OwnedData>
+using TensorType = std::conditional_t<OwnedData,
+                                      Eigen::TensorFixedSize<T, Sizes>,
+                                      Eigen::TensorMap<Eigen::TensorFixedSize<T, Sizes>>>;
+
+template<typename ModelVariant, typename real_type, bool OwnedData>
 struct ChildModelState {
   ChildModelState(const Parameters<ModelVariant, real_type> &pars) {}
 
   void reset() {}
 };
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 struct BaseModelState {
-  TensorFixedSize<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>> p_total_pop;
-  real_type births;
-  TensorFixedSize<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>> p_total_pop_natural_deaths;
-  TensorFixedSize<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>> p_hiv_pop;
-  TensorFixedSize<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>> p_hiv_pop_natural_deaths;
-  TensorFixedSize<real_type, Sizes<hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>> h_hiv_adult;
-  TensorFixedSize<real_type, Sizes<hTS<ModelVariant>, hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>> h_art_adult;
-  TensorFixedSize<real_type, Sizes<hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>> h_hiv_deaths_no_art;
-  TensorFixedSize<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>> p_infections;
-  TensorFixedSize<real_type, Sizes<hTS<ModelVariant>, hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>> h_hiv_deaths_art;
-  TensorFixedSize<real_type, Sizes<hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>> h_art_initiation;
-  TensorFixedSize<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>> p_hiv_deaths;
+  TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData> p_total_pop;
+  TensorType<real_type, Sizes<1>, OwnedData> births;
+  TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData> p_total_pop_natural_deaths;
+  TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData> p_hiv_pop;
+  TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData> p_hiv_pop_natural_deaths;
+  TensorType<real_type, Sizes<hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>, OwnedData> h_hiv_adult;
+  TensorType<real_type, Sizes<hTS<ModelVariant>, hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>, OwnedData> h_art_adult;
+  TensorType<real_type, Sizes<hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>, OwnedData> h_hiv_deaths_no_art;
+  TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData> p_infections;
+  TensorType<real_type, Sizes<hTS<ModelVariant>, hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>, OwnedData> h_hiv_deaths_art;
+  TensorType<real_type, Sizes<hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>, OwnedData> h_art_initiation;
+  TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData> p_hiv_deaths;
 
   BaseModelState(const Parameters<ModelVariant, real_type> &pars) {
+    static_assert(OwnedData,
+      "BaseModelState can only be constructed from parameters if it owns the data.");
+    p_total_pop = TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData>();
+    births = TensorType<real_type, Sizes<1>, OwnedData>();
+    p_total_pop_natural_deaths = TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData>();
+    p_hiv_pop = TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData>();
+    p_hiv_pop_natural_deaths = TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData>();
+    h_hiv_adult = TensorType<real_type, Sizes<hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>, OwnedData>();
+    h_art_adult = TensorType<real_type, Sizes<hTS<ModelVariant>, hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>, OwnedData>();
+    h_hiv_deaths_no_art = TensorType<real_type, Sizes<hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>, OwnedData>();
+    p_infections = TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData>();
+    h_hiv_deaths_art = TensorType<real_type, Sizes<hTS<ModelVariant>, hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>, OwnedData>();
+    h_art_initiation = TensorType<real_type, Sizes<hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>, OwnedData>();
+    p_hiv_deaths = TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData>();
+
     reset();
   }
 
   BaseModelState(
-    const TensorFixedSize<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>>& p_total_pop,
-    real_type births,
-    const TensorFixedSize<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>>& p_total_pop_natural_deaths,
-    const TensorFixedSize<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>>& p_hiv_pop,
-    const TensorFixedSize<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>>& p_hiv_pop_natural_deaths,
-    const TensorFixedSize<real_type, Sizes<hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>>& h_hiv_adult,
-    const TensorFixedSize<real_type, Sizes<hTS<ModelVariant>, hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>>& h_art_adult,
-    const TensorFixedSize<real_type, Sizes<hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>>& h_hiv_deaths_no_art,
-    const TensorFixedSize<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>>& p_infections,
-    const TensorFixedSize<real_type, Sizes<hTS<ModelVariant>, hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>>& h_hiv_deaths_art,
-    const TensorFixedSize<real_type, Sizes<hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>>& h_art_initiation,
-    const TensorFixedSize<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>>& p_hiv_deaths
+    const TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData>& p_total_pop,
+    const TensorType<real_type, Sizes<1>, OwnedData>& births,
+    const TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData>& p_total_pop_natural_deaths,
+    const TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData>& p_hiv_pop,
+    const TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData>& p_hiv_pop_natural_deaths,
+    const TensorType<real_type, Sizes<hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>, OwnedData>& h_hiv_adult,
+    const TensorType<real_type, Sizes<hTS<ModelVariant>, hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>, OwnedData>& h_art_adult,
+    const TensorType<real_type, Sizes<hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>, OwnedData>& h_hiv_deaths_no_art,
+    const TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData>& p_infections,
+    const TensorType<real_type, Sizes<hTS<ModelVariant>, hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>, OwnedData>& h_hiv_deaths_art,
+    const TensorType<real_type, Sizes<hDS<ModelVariant>, hAG<ModelVariant>, NS<ModelVariant>>, OwnedData>& h_art_initiation,
+    const TensorType<real_type, Sizes<pAG<ModelVariant>, NS<ModelVariant>>, OwnedData>& p_hiv_deaths
   ) :
     p_total_pop(p_total_pop),
     births(births),
@@ -71,7 +92,7 @@ struct BaseModelState {
 
   void reset() {
     p_total_pop.setZero();
-    births = 0;
+    births.setZero();
     p_total_pop_natural_deaths.setZero();
     p_hiv_pop.setZero();
     p_hiv_pop_natural_deaths.setZero();
@@ -85,20 +106,20 @@ struct BaseModelState {
   }
 };
 
-template<typename real_type>
-struct ChildModelState<ChildModel, real_type> {
-  TensorFixedSize<real_type, Sizes<hc1DS<ChildModel>, hcTT<ChildModel>, hc1AG<ChildModel>, NS<ChildModel>>> hc1_hiv_pop;
-  TensorFixedSize<real_type, Sizes<hc2DS<ChildModel>, hcTT<ChildModel>, hc2AG<ChildModel>, NS<ChildModel>>> hc2_hiv_pop;
-  TensorFixedSize<real_type, Sizes<hTS<ChildModel>, hc1DS<ChildModel>, hc1AG<ChildModel>, NS<ChildModel>>> hc1_art_pop;
-  TensorFixedSize<real_type, Sizes<hTS<ChildModel>, hc2DS<ChildModel>, hc2AG<ChildModel>, NS<ChildModel>>> hc2_art_pop;
-  TensorFixedSize<real_type, Sizes<hc1DS<ChildModel>, hcTT<ChildModel>, hc1AG<ChildModel>, NS<ChildModel>>> hc1_noart_aids_deaths;
-  TensorFixedSize<real_type, Sizes<hc2DS<ChildModel>, hcTT<ChildModel>, hc2AG<ChildModel>, NS<ChildModel>>> hc2_noart_aids_deaths;
-  TensorFixedSize<real_type, Sizes<hTS<ChildModel>, hc1DS<ChildModel>, hc1AG<ChildModel>, NS<ChildModel>>> hc1_art_aids_deaths;
-  TensorFixedSize<real_type, Sizes<hTS<ChildModel>, hc2DS<ChildModel>, hc2AG<ChildModel>, NS<ChildModel>>> hc2_art_aids_deaths;
+template<typename real_type, bool OwnedData>
+struct ChildModelState<ChildModel, real_type, OwnedData> {
+  TensorType<real_type, Sizes<hc1DS<ChildModel>, hcTT<ChildModel>, hc1AG<ChildModel>, NS<ChildModel>>, OwnedData> hc1_hiv_pop;
+  TensorType<real_type, Sizes<hc2DS<ChildModel>, hcTT<ChildModel>, hc2AG<ChildModel>, NS<ChildModel>>, OwnedData> hc2_hiv_pop;
+  TensorType<real_type, Sizes<hTS<ChildModel>, hc1DS<ChildModel>, hc1AG<ChildModel>, NS<ChildModel>>, OwnedData> hc1_art_pop;
+  TensorType<real_type, Sizes<hTS<ChildModel>, hc2DS<ChildModel>, hc2AG<ChildModel>, NS<ChildModel>>, OwnedData> hc2_art_pop;
+  TensorType<real_type, Sizes<hc1DS<ChildModel>, hcTT<ChildModel>, hc1AG<ChildModel>, NS<ChildModel>>, OwnedData> hc1_noart_aids_deaths;
+  TensorType<real_type, Sizes<hc2DS<ChildModel>, hcTT<ChildModel>, hc2AG<ChildModel>, NS<ChildModel>>, OwnedData> hc2_noart_aids_deaths;
+  TensorType<real_type, Sizes<hTS<ChildModel>, hc1DS<ChildModel>, hc1AG<ChildModel>, NS<ChildModel>>, OwnedData> hc1_art_aids_deaths;
+  TensorType<real_type, Sizes<hTS<ChildModel>, hc2DS<ChildModel>, hc2AG<ChildModel>, NS<ChildModel>>, OwnedData> hc2_art_aids_deaths;
   real_type hiv_births;
-  TensorFixedSize<real_type, Sizes<4>> hc_art_total;
-  TensorFixedSize<real_type, Sizes<4>> hc_art_init;
-  TensorFixedSize<real_type, Sizes<hc1DS<ChildModel>, hcTT<ChildModel>, 15, NS<ChildModel>>> hc_art_need_init;
+  TensorType<real_type, Sizes<4>, OwnedData> hc_art_total;
+  TensorType<real_type, Sizes<4>, OwnedData> hc_art_init;
+  TensorType<real_type, Sizes<hc1DS<ChildModel>, hcTT<ChildModel>, 15, NS<ChildModel>>, OwnedData> hc_art_need_init;
   real_type ctx_need;
   real_type ctx_mean;
 
@@ -124,17 +145,17 @@ struct ChildModelState<ChildModel, real_type> {
   }
 };
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 struct State {
-  BaseModelState<ModelVariant, real_type> base;
-  ChildModelState<ModelVariant, real_type> children;
+  BaseModelState<ModelVariant, real_type, OwnedData> base;
+  ChildModelState<ModelVariant, real_type, OwnedData> children;
 
   State(const Parameters<ModelVariant, real_type> &pars) :
       base(pars),
       children(pars) {}
 
-  State(const BaseModelState<ModelVariant, real_type> &base,
-        const ChildModelState<ModelVariant, real_type> &children)
+  State(const BaseModelState<ModelVariant, real_type, OwnedData> &base,
+        const ChildModelState<ModelVariant, real_type, OwnedData> &children)
     : base(base),
       children(children) {}
 

--- a/inst/include/hiv_demographic_projection.hpp
+++ b/inst/include/hiv_demographic_projection.hpp
@@ -8,11 +8,11 @@ namespace leapfrog {
 
 namespace internal {
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_hiv_ageing_and_mortality(int time_step,
                                   const Parameters<ModelVariant, real_type> &pars,
-                                  const State<ModelVariant, real_type> &state_curr,
-                                  State<ModelVariant, real_type> &state_next,
+                                  const State<ModelVariant, real_type, OwnedData> &state_curr,
+                                  State<ModelVariant, real_type, OwnedData> &state_next,
                                   IntermediateData<ModelVariant, real_type> &intermediate) {
   const auto demog = pars.base.demography;
   constexpr auto ss = StateSpace<ModelVariant>().base;
@@ -36,11 +36,11 @@ void run_hiv_ageing_and_mortality(int time_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_age_15_entrants(int time_step,
                          const Parameters<ModelVariant, real_type> &pars,
-                         const State<ModelVariant, real_type> &state_curr,
-                         State<ModelVariant, real_type> &state_next,
+                         const State<ModelVariant, real_type, OwnedData> &state_curr,
+                         State<ModelVariant, real_type, OwnedData> &state_next,
                          IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "run_hiv_child_infections can only be called for model variants where run_child_model is true");
@@ -63,11 +63,11 @@ void run_age_15_entrants(int time_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_hiv_and_art_stratified_ageing(int time_step,
                                        const Parameters<ModelVariant, real_type> &pars,
-                                       const State<ModelVariant, real_type> &state_curr,
-                                       State<ModelVariant, real_type> &state_next,
+                                       const State<ModelVariant, real_type, OwnedData> &state_curr,
+                                       State<ModelVariant, real_type, OwnedData> &state_next,
                                        IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss = StateSpace<ModelVariant>().base;
   constexpr auto hc_ss = StateSpace<ModelVariant>().children;
@@ -141,12 +141,12 @@ void run_hiv_and_art_stratified_ageing(int time_step,
 }
 
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_hiv_and_art_stratified_deaths_and_migration(
     int time_step,
     const Parameters<ModelVariant, real_type> &pars,
-    const State<ModelVariant, real_type> &state_curr,
-    State<ModelVariant, real_type> &state_next,
+    const State<ModelVariant, real_type, OwnedData> &state_curr,
+    State<ModelVariant, real_type, OwnedData> &state_next,
     IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss = StateSpace<ModelVariant>().base;
   for (int g = 0; g < ss.NS; ++g) {
@@ -197,11 +197,11 @@ void run_hiv_and_art_stratified_deaths_and_migration(
 
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_hiv_pop_demographic_projection(int time_step,
                                         const Parameters<ModelVariant, real_type> &pars,
-                                        const State<ModelVariant, real_type> &state_curr,
-                                        State<ModelVariant, real_type> &state_next,
+                                        const State<ModelVariant, real_type, OwnedData> &state_curr,
+                                        State<ModelVariant, real_type, OwnedData> &state_next,
                                         internal::IntermediateData<ModelVariant, real_type> &intermediate) {
 
   internal::run_hiv_ageing_and_mortality<ModelVariant>(time_step, pars, state_curr, state_next,

--- a/inst/include/leapfrog_py.hpp
+++ b/inst/include/leapfrog_py.hpp
@@ -22,11 +22,11 @@ namespace leapfrog {
  * @param state_next The next state of the model.
  * @return None, updates state_next in place
  */
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void project_single_year(int time_step,
                          const Parameters<ModelVariant, real_type> &pars,
-                         const State<ModelVariant, real_type> &state_curr,
-                         State<ModelVariant, real_type> &state_next) {
+                         const State<ModelVariant, real_type, OwnedData> &state_curr,
+                         State<ModelVariant, real_type, OwnedData> &state_next) {
 
   internal::IntermediateData<ModelVariant, real_type> intermediate(pars.base.options.hAG_15plus);
   intermediate.reset();

--- a/inst/include/model_simulation.hpp
+++ b/inst/include/model_simulation.hpp
@@ -24,11 +24,11 @@ void distribute_rate_over_sexes(
       (total_neg) / denominator;
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_calculate_incidence_rate(int time_step,
                                   const Parameters<ModelVariant, real_type> &pars,
-                                  const State<ModelVariant, real_type> &state_curr,
-                                  State<ModelVariant, real_type> &state_next,
+                                  const State<ModelVariant, real_type, OwnedData> &state_curr,
+                                  State<ModelVariant, real_type, OwnedData> &state_next,
                                   IntermediateData<ModelVariant, real_type> &intermediate) {
   const auto adult_incidence_first_age_group = pars.base.options.adult_incidence_first_age_group;
   constexpr auto ss = StateSpace<ModelVariant>().base;
@@ -46,12 +46,12 @@ void run_calculate_incidence_rate(int time_step,
 }
 
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_disease_progression_and_mortality(int hiv_step,
                                            int time_step,
                                            const Parameters<ModelVariant, real_type> &pars,
-                                           const State<ModelVariant, real_type> &state_curr,
-                                           State<ModelVariant, real_type> &state_next,
+                                           const State<ModelVariant, real_type, OwnedData> &state_curr,
+                                           State<ModelVariant, real_type, OwnedData> &state_next,
                                            IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss = StateSpace<ModelVariant>().base;
   const auto natural_history = pars.base.natural_history;
@@ -98,12 +98,12 @@ void run_disease_progression_and_mortality(int hiv_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_new_p_infections(int hiv_step,
                           int time_step,
                           const Parameters<ModelVariant, real_type> &pars,
-                          const State<ModelVariant, real_type> &state_curr,
-                          State<ModelVariant, real_type> &state_next,
+                          const State<ModelVariant, real_type, OwnedData> &state_curr,
+                          State<ModelVariant, real_type, OwnedData> &state_next,
                           IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss = StateSpace<ModelVariant>().base;
   const auto incidence = pars.base.incidence;
@@ -140,12 +140,12 @@ void run_new_p_infections(int hiv_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_new_hiv_p_infections(int hiv_step,
                               int time_step,
                               const Parameters<ModelVariant, real_type> &pars,
-                              const State<ModelVariant, real_type> &state_curr,
-                              State<ModelVariant, real_type> &state_next,
+                              const State<ModelVariant, real_type, OwnedData> &state_curr,
+                              State<ModelVariant, real_type, OwnedData> &state_next,
                               IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss = StateSpace<ModelVariant>().base;
   const auto natural_history = pars.base.natural_history;
@@ -175,12 +175,12 @@ void run_new_hiv_p_infections(int hiv_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_art_progression_and_mortality(int hiv_step,
                                        int time_step,
                                        const Parameters<ModelVariant, real_type> &pars,
-                                       const State<ModelVariant, real_type> &state_curr,
-                                       State<ModelVariant, real_type> &state_next,
+                                       const State<ModelVariant, real_type, OwnedData> &state_curr,
+                                       State<ModelVariant, real_type, OwnedData> &state_next,
                                        IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss = StateSpace<ModelVariant>().base;
   const auto art = pars.base.art;
@@ -227,12 +227,12 @@ void run_art_progression_and_mortality(int hiv_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_h_art_initiation(int hiv_step,
                           int time_step,
                           const Parameters<ModelVariant, real_type> &pars,
-                          const State<ModelVariant, real_type> &state_curr,
-                          State<ModelVariant, real_type> &state_next,
+                          const State<ModelVariant, real_type, OwnedData> &state_curr,
+                          State<ModelVariant, real_type, OwnedData> &state_next,
                           IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss = StateSpace<ModelVariant>().base;
   const auto natural_history = pars.base.natural_history;
@@ -369,12 +369,12 @@ void run_h_art_initiation(int hiv_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_update_art_stratification(int hiv_step,
                                    int time_step,
                                    const Parameters<ModelVariant, real_type> &pars,
-                                   const State<ModelVariant, real_type> &state_curr,
-                                   State<ModelVariant, real_type> &state_next,
+                                   const State<ModelVariant, real_type, OwnedData> &state_curr,
+                                   State<ModelVariant, real_type, OwnedData> &state_next,
                                    IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss = StateSpace<ModelVariant>().base;
   for (int g = 0; g < ss.NS; ++g) {
@@ -389,12 +389,12 @@ void run_update_art_stratification(int hiv_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_update_hiv_stratification(int hiv_step,
                                    int time_step,
                                    const Parameters<ModelVariant, real_type> &pars,
-                                   const State<ModelVariant, real_type> &state_curr,
-                                   State<ModelVariant, real_type> &state_next,
+                                   const State<ModelVariant, real_type, OwnedData> &state_curr,
+                                   State<ModelVariant, real_type, OwnedData> &state_next,
                                    IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss = StateSpace<ModelVariant>().base;
 
@@ -408,12 +408,12 @@ void run_update_hiv_stratification(int hiv_step,
   }
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_remove_p_hiv_deaths(int hiv_step,
                              int time_step,
                              const Parameters<ModelVariant, real_type> &pars,
-                             const State<ModelVariant, real_type> &state_curr,
-                             State<ModelVariant, real_type> &state_next,
+                             const State<ModelVariant, real_type, OwnedData> &state_curr,
+                             State<ModelVariant, real_type, OwnedData> &state_next,
                              IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss = StateSpace<ModelVariant>().base;
   for (int g = 0; g < ss.NS; ++g) {
@@ -449,11 +449,11 @@ void run_remove_p_hiv_deaths(int hiv_step,
 
 }
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void run_hiv_model_simulation(int time_step,
                               const Parameters<ModelVariant, real_type> &pars,
-                              const State<ModelVariant, real_type> &state_curr,
-                              State<ModelVariant, real_type> &state_next,
+                              const State<ModelVariant, real_type, OwnedData> &state_curr,
+                              State<ModelVariant, real_type, OwnedData> &state_next,
                               internal::IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss = StateSpace<ModelVariant>().base;
   const auto art = pars.base.art;

--- a/inst/include/project_year.hpp
+++ b/inst/include/project_year.hpp
@@ -11,11 +11,11 @@ namespace leapfrog {
 
 namespace internal {
 
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void project_year(int time_step,
                   const Parameters<ModelVariant, real_type> &pars,
-                  const State<ModelVariant, real_type> &state_curr,
-                  State<ModelVariant, real_type> &state_next,
+                  const State<ModelVariant, real_type, OwnedData> &state_curr,
+                  State<ModelVariant, real_type, OwnedData> &state_next,
                   IntermediateData<ModelVariant, real_type> &intermediate) {
   run_general_pop_demographic_projection<ModelVariant>(time_step, pars, state_curr, state_next,
                                                        intermediate);

--- a/inst/include/state_saver.hpp
+++ b/inst/include/state_saver.hpp
@@ -42,7 +42,7 @@ public:
   }
 
 
-  void save_state(const State<ModelVariant, real_type> &state, int current_year) {
+  void save_state(const State<ModelVariant, real_type, true> &state, int current_year) {
     for (size_t i = 0; i < save_steps.size(); ++i) {
       if (current_year == save_steps[i]) {
         base.save_state(full_state.base, i, state);

--- a/inst/standalone_model/simulate_model.cpp
+++ b/inst/standalone_model/simulate_model.cpp
@@ -266,10 +266,10 @@ int main(int argc, char *argv[]) {
   }
 
   for (size_t i = 0; i < n_runs; ++i) {
-    auto state_current = leapfrog::State<leapfrog::BaseModelFullAgeStratification, double>(
+    auto state_current = leapfrog::State<leapfrog::BaseModelFullAgeStratification, double, true>(
         params);
     auto state_next = state_current;
-    leapfrog::set_initial_state<leapfrog::BaseModelFullAgeStratification, double>(state_current, params);
+    leapfrog::set_initial_state<leapfrog::BaseModelFullAgeStratification, double, true>(state_current, params);
 
     // Save initial state
     state_output.save_state(state_current, 0);

--- a/leapfrog-py/scripts/benchmark.py
+++ b/leapfrog-py/scripts/benchmark.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python
 
 import os
-import numpy as np
-import timeit
 import statistics
+import timeit
+
+import numpy as np
 from leapfrog_py.leapfrog_py import (
     project_single_year,
-    run_leapfrog,
+    run_leapfrog,  # noqa F401
     set_initial_state,
 )
 
 
-def pretty_timeit(stmt, globals, setup='pass', repeat=5, number=1000):
-    times = timeit.repeat(stmt=stmt, setup=setup, globals=globals, repeat=repeat, number=number)
+def pretty_timeit(stmt, globals, setup="pass", repeat=5, number=1000):
+    times = timeit.repeat(
+        stmt=stmt, setup=setup, globals=globals, repeat=repeat, number=number
+    )
 
     times_ms = [time * 1000 for time in times]
 
@@ -39,23 +42,47 @@ def input_file_path(file_name):
 def parameters():
     return {
         "adult_on_art": read_standalone_data(input_file_path("adults_on_art")),
-        "adults_on_art_is_percent": read_standalone_data(input_file_path("adults_on_art_is_percent")),
-        "age_specific_fertility_rate": read_standalone_data(input_file_path("age_specific_fertility_rate")),
+        "adults_on_art_is_percent": read_standalone_data(
+            input_file_path("adults_on_art_is_percent")
+        ),
+        "age_specific_fertility_rate": read_standalone_data(
+            input_file_path("age_specific_fertility_rate")
+        ),
         "art_dropout": read_standalone_data(input_file_path("art_dropout")),
-        "art_mortality_rate_full": read_standalone_data(input_file_path("art_mortality_rate_full")),
-        "art_mortality_time_rate_ratio": read_standalone_data(input_file_path("art_mortality_time_rate_ratio")),
+        "art_mortality_rate_full": read_standalone_data(
+            input_file_path("art_mortality_rate_full")
+        ),
+        "art_mortality_time_rate_ratio": read_standalone_data(
+            input_file_path("art_mortality_time_rate_ratio")
+        ),
         "basepop": read_standalone_data(input_file_path("basepop")),
-        "births_sex_prop": read_standalone_data(input_file_path("births_sex_prop")),
-        "cd4_initial_distribution_full": read_standalone_data(input_file_path("cd4_initial_distribution_full")),
-        "cd4_mortality_full": read_standalone_data(input_file_path("cd4_mortality_full")),
-        "cd4_progression_full": read_standalone_data(input_file_path("cd4_progression_full")),
+        "births_sex_prop": read_standalone_data(
+            input_file_path("births_sex_prop")
+        ),
+        "cd4_initial_distribution_full": read_standalone_data(
+            input_file_path("cd4_initial_distribution_full")
+        ),
+        "cd4_mortality_full": read_standalone_data(
+            input_file_path("cd4_mortality_full")
+        ),
+        "cd4_progression_full": read_standalone_data(
+            input_file_path("cd4_progression_full")
+        ),
         "idx_hm_elig": read_standalone_data(input_file_path("idx_hm_elig")),
-        "relative_risk_age": read_standalone_data(input_file_path("incidence_age_rate_ratio")),
-        "incidence_rate": read_standalone_data(input_file_path("incidence_rate")),
-        "relative_risk_sex": read_standalone_data(input_file_path("incidence_sex_rate_ratio")),
+        "relative_risk_age": read_standalone_data(
+            input_file_path("incidence_age_rate_ratio")
+        ),
+        "incidence_rate": read_standalone_data(
+            input_file_path("incidence_rate")
+        ),
+        "relative_risk_sex": read_standalone_data(
+            input_file_path("incidence_sex_rate_ratio")
+        ),
         "net_migration": read_standalone_data(input_file_path("net_migration")),
-        "survival_probability": read_standalone_data(input_file_path("survival_probability")),
-        "h_art_stage_dur": np.array([0.5, 0.5], order="F")
+        "survival_probability": read_standalone_data(
+            input_file_path("survival_probability")
+        ),
+        "h_art_stage_dur": np.array([0.5, 0.5], order="F"),
     }
 
 
@@ -121,6 +148,16 @@ def fit_by_single(parameters, state):
 
 params = parameters()
 print("Full model benchmark")
-print(pretty_timeit("run_leapfrog(params)", globals=locals(), number=1, repeat=50))
+print(
+    pretty_timeit("run_leapfrog(params)", globals=locals(), number=1, repeat=50)
+)
 print("Year by year benchmark")
-print(pretty_timeit("fit_by_single(params, s)", globals=locals(), setup="s = state()", number=1, repeat=50))
+print(
+    pretty_timeit(
+        "fit_by_single(params, s)",
+        globals=locals(),
+        setup="s = state()",
+        number=1,
+        repeat=50,
+    )
+)

--- a/leapfrog-py/scripts/benchmark.py
+++ b/leapfrog-py/scripts/benchmark.py
@@ -10,11 +10,6 @@ from leapfrog_py.leapfrog_py import (
     set_initial_state,
 )
 
-import leapfrog_py.leapfrog_py
-print(leapfrog_py.__file__)
-import leapfrog
-print(leapfrog.__file__)
-
 
 def pretty_timeit(stmt, globals, setup='pass', repeat=5, number=1000):
     times = timeit.repeat(stmt=stmt, setup=setup, globals=globals, repeat=repeat, number=number)
@@ -126,6 +121,6 @@ def fit_by_single(parameters, state):
 
 params = parameters()
 print("Full model benchmark")
-print(pretty_timeit("run_leapfrog(params)", globals=locals(), number=1, repeat=25))
+print(pretty_timeit("run_leapfrog(params)", globals=locals(), number=1, repeat=50))
 print("Year by year benchmark")
-print(pretty_timeit("fit_by_single(params, s)", globals=locals(), setup="s = state()", number=1, repeat=25))
+print(pretty_timeit("fit_by_single(params, s)", globals=locals(), setup="s = state()", number=1, repeat=50))

--- a/leapfrog-py/scripts/benchmark.py
+++ b/leapfrog-py/scripts/benchmark.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+
+import os
+import numpy as np
+import timeit
+import statistics
+from leapfrog_py.leapfrog_py import (
+    project_single_year,
+    run_leapfrog,
+    set_initial_state,
+)
+
+import leapfrog_py.leapfrog_py
+print(leapfrog_py.__file__)
+import leapfrog
+print(leapfrog.__file__)
+
+
+def pretty_timeit(stmt, globals, setup='pass', repeat=5, number=1000):
+    times = timeit.repeat(stmt=stmt, setup=setup, globals=globals, repeat=repeat, number=number)
+
+    times_ms = [time * 1000 for time in times]
+
+    min_time = min(times_ms)
+    median_time = statistics.median(times_ms)
+    max_time = max(times_ms)
+    total_time = sum(times_ms)
+
+    output = (
+        f"Minimum Time: {min_time:.1f} ms\n"
+        f"Median Time: {median_time:.1f} ms\n"
+        f"Maximum Time: {max_time:.1f} ms\n"
+        f"Number of Iterations: {repeat}\n"
+        f"Total Time: {total_time:.1f} ms\n"
+    )
+
+    return output
+
+
+def input_file_path(file_name):
+    return os.path.join("../inst/standalone_model/data/", file_name)
+
+
+def parameters():
+    return {
+        "adult_on_art": read_standalone_data(input_file_path("adults_on_art")),
+        "adults_on_art_is_percent": read_standalone_data(input_file_path("adults_on_art_is_percent")),
+        "age_specific_fertility_rate": read_standalone_data(input_file_path("age_specific_fertility_rate")),
+        "art_dropout": read_standalone_data(input_file_path("art_dropout")),
+        "art_mortality_rate_full": read_standalone_data(input_file_path("art_mortality_rate_full")),
+        "art_mortality_time_rate_ratio": read_standalone_data(input_file_path("art_mortality_time_rate_ratio")),
+        "basepop": read_standalone_data(input_file_path("basepop")),
+        "births_sex_prop": read_standalone_data(input_file_path("births_sex_prop")),
+        "cd4_initial_distribution_full": read_standalone_data(input_file_path("cd4_initial_distribution_full")),
+        "cd4_mortality_full": read_standalone_data(input_file_path("cd4_mortality_full")),
+        "cd4_progression_full": read_standalone_data(input_file_path("cd4_progression_full")),
+        "idx_hm_elig": read_standalone_data(input_file_path("idx_hm_elig")),
+        "relative_risk_age": read_standalone_data(input_file_path("incidence_age_rate_ratio")),
+        "incidence_rate": read_standalone_data(input_file_path("incidence_rate")),
+        "relative_risk_sex": read_standalone_data(input_file_path("incidence_sex_rate_ratio")),
+        "net_migration": read_standalone_data(input_file_path("net_migration")),
+        "survival_probability": read_standalone_data(input_file_path("survival_probability")),
+        "h_art_stage_dur": np.array([0.5, 0.5], order="F")
+    }
+
+
+def state():
+    NS = 2  # noqa: N806
+    pAG = 81  # noqa: N806
+    hAG = 66  # noqa: N806
+    hDS = 7  # noqa: N806
+    hTS = 3  # noqa: N806
+    no_output_years = 61
+    return {
+        "p_total_pop": np.zeros((pAG, NS, no_output_years), order="F"),
+        "births": np.zeros(no_output_years),
+        "p_total_pop_natural_deaths": np.zeros(
+            (pAG, NS, no_output_years), order="F"
+        ),
+        "p_hiv_pop": np.zeros((pAG, NS, no_output_years), order="F"),
+        "p_hiv_pop_natural_deaths": np.zeros(
+            (pAG, NS, no_output_years), order="F"
+        ),
+        "h_hiv_adult": np.zeros((hDS, hAG, NS, no_output_years), order="F"),
+        "h_art_adult": np.zeros(
+            (hTS, hDS, hAG, NS, no_output_years), order="F"
+        ),
+        "h_hiv_deaths_no_art": np.zeros(
+            (hDS, hAG, NS, no_output_years), order="F"
+        ),
+        "p_infections": np.zeros((pAG, NS, no_output_years), order="F"),
+        "h_hiv_deaths_art": np.zeros(
+            (hTS, hDS, hAG, NS, no_output_years), order="F"
+        ),
+        "h_art_initiation": np.zeros(
+            (hDS, hAG, NS, no_output_years), order="F"
+        ),
+        "p_hiv_deaths": np.zeros((pAG, NS, no_output_years), order="F"),
+    }
+
+
+def read_standalone_data(file_path):
+    with open(file_path) as file:
+        # Read the type
+        data_type = file.readline().strip()
+        # Map Fortran types to numpy types
+        type_map = {"double": np.float64, "int": np.int32}
+        if data_type not in type_map:
+            msg = f"Unsupported data type: {data_type}"
+            raise ValueError(msg)
+        np_type = type_map[data_type]
+        # Read the dimensions
+        dimensions = tuple(map(int, file.readline().strip().split(",")))
+        # Read the data
+        data = np.fromfile(file, dtype=np_type, sep=",")
+        # Reshape data into Fortran-order array
+        array = np.reshape(data, dimensions, order="F")
+        return array
+
+
+def fit_by_single(parameters, state):
+    set_initial_state(parameters, state)
+    for i in range(1, 61):
+        project_single_year(i, parameters, state)
+
+
+params = parameters()
+print("Full model benchmark")
+print(pretty_timeit("run_leapfrog(params)", globals=locals(), number=1, repeat=25))
+print("Year by year benchmark")
+print(pretty_timeit("fit_by_single(params, s)", globals=locals(), setup="s = state()", number=1, repeat=25))

--- a/leapfrog-py/src/leapfrog/interface.cpp
+++ b/leapfrog-py/src/leapfrog/interface.cpp
@@ -10,7 +10,6 @@ namespace py = pybind11;
 
 namespace {
 using Eigen::Sizes;
-using Eigen::TensorFixedSize;
 }
 
 PYBIND11_MODULE(leapfrog, m) {
@@ -180,20 +179,19 @@ PYBIND11_MODULE(leapfrog, m) {
         .def_readonly("base", &leapfrog::Parameters<leapfrog::BaseModelFullAgeStratification, double>::base)
         .def_readonly("children", &leapfrog::Parameters<leapfrog::BaseModelFullAgeStratification, double>::children);
 
-    py::class_<leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double>>(m, "BaseModelState")
-        .def(py::init<const leapfrog::Parameters<leapfrog::BaseModelFullAgeStratification, double>&>())
-        .def(py::init<const TensorFixedSize<double, Sizes<leapfrog::pAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>>&,
-                      double,
-                      TensorFixedSize<double, Sizes<leapfrog::pAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>>&,
-                      TensorFixedSize<double, Sizes<leapfrog::pAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>>&,
-                      TensorFixedSize<double, Sizes<leapfrog::pAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>>&,
-                      TensorFixedSize<double, Sizes<leapfrog::hDS<leapfrog::BaseModelFullAgeStratification>, leapfrog::hAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>>&,
-                      TensorFixedSize<double, Sizes<leapfrog::hTS<leapfrog::BaseModelFullAgeStratification>, leapfrog::hDS<leapfrog::BaseModelFullAgeStratification>, leapfrog::hAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>>&,
-                      TensorFixedSize<double, Sizes<leapfrog::hDS<leapfrog::BaseModelFullAgeStratification>, leapfrog::hAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>>&,
-                      TensorFixedSize<double, Sizes<leapfrog::pAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>>&,
-                      TensorFixedSize<double, Sizes<leapfrog::hTS<leapfrog::BaseModelFullAgeStratification>, leapfrog::hDS<leapfrog::BaseModelFullAgeStratification>, leapfrog::hAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>>&,
-                      TensorFixedSize<double, Sizes<leapfrog::hDS<leapfrog::BaseModelFullAgeStratification>, leapfrog::hAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>>&,
-                      TensorFixedSize<double, Sizes<leapfrog::pAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>>&>(),
+    py::class_<leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double, false>>(m, "BaseModelState")
+        .def(py::init<const leapfrog::TensorType<double, Sizes<leapfrog::pAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>, false>&,
+                      const leapfrog::TensorType<double, Sizes<1>, false>&,
+                      const leapfrog::TensorType<double, Sizes<leapfrog::pAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>, false>&,
+                      const leapfrog::TensorType<double, Sizes<leapfrog::pAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>, false>&,
+                      const leapfrog::TensorType<double, Sizes<leapfrog::pAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>, false>&,
+                      const leapfrog::TensorType<double, Sizes<leapfrog::hDS<leapfrog::BaseModelFullAgeStratification>, leapfrog::hAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>, false>&,
+                      const leapfrog::TensorType<double, Sizes<leapfrog::hTS<leapfrog::BaseModelFullAgeStratification>, leapfrog::hDS<leapfrog::BaseModelFullAgeStratification>, leapfrog::hAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>, false>&,
+                      const leapfrog::TensorType<double, Sizes<leapfrog::hDS<leapfrog::BaseModelFullAgeStratification>, leapfrog::hAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>, false>&,
+                      const leapfrog::TensorType<double, Sizes<leapfrog::pAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>, false>&,
+                      const leapfrog::TensorType<double, Sizes<leapfrog::hTS<leapfrog::BaseModelFullAgeStratification>, leapfrog::hDS<leapfrog::BaseModelFullAgeStratification>, leapfrog::hAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>, false>&,
+                      const leapfrog::TensorType<double, Sizes<leapfrog::hDS<leapfrog::BaseModelFullAgeStratification>, leapfrog::hAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>, false>&,
+                      const leapfrog::TensorType<double, Sizes<leapfrog::pAG<leapfrog::BaseModelFullAgeStratification>, leapfrog::NS<leapfrog::BaseModelFullAgeStratification>>, false>&>(),
                       py::arg("p_total_pop"),
                       py::arg("births"),
                       py::arg("p_total_pop_natural_deaths"),
@@ -206,35 +204,34 @@ PYBIND11_MODULE(leapfrog, m) {
                       py::arg("h_hiv_deaths_art"),
                       py::arg("h_art_initiation"),
                       py::arg("p_hiv_deaths"))
-        .def("reset", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double>::reset)
-        .def_readonly("p_total_pop", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double>::p_total_pop)
-        .def_readonly("births", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double>::births)
-        .def_readonly("p_total_pop_natural_deaths", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double>::p_total_pop_natural_deaths)
-        .def_readonly("p_hiv_pop", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double>::p_hiv_pop)
-        .def_readonly("p_hiv_pop_natural_deaths", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double>::p_hiv_pop_natural_deaths)
-        .def_readonly("h_hiv_adult", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double>::h_hiv_adult)
-        .def_readonly("h_art_adult", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double>::h_art_adult)
-        .def_readonly("h_hiv_deaths_no_art", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double>::h_hiv_deaths_no_art)
-        .def_readonly("p_infections", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double>::p_infections)
-        .def_readonly("h_hiv_deaths_art", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double>::h_hiv_deaths_art)
-        .def_readonly("h_art_initiation", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double>::h_art_initiation)
-        .def_readonly("p_hiv_deaths", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double>::p_hiv_deaths);
+        .def("reset", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double, false>::reset)
+        .def_readonly("p_total_pop", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double, false>::p_total_pop)
+        .def_readonly("births", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double, false>::births)
+        .def_readonly("p_total_pop_natural_deaths", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double, false>::p_total_pop_natural_deaths)
+        .def_readonly("p_hiv_pop", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double, false>::p_hiv_pop)
+        .def_readonly("p_hiv_pop_natural_deaths", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double, false>::p_hiv_pop_natural_deaths)
+        .def_readonly("h_hiv_adult", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double, false>::h_hiv_adult)
+        .def_readonly("h_art_adult", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double, false>::h_art_adult)
+        .def_readonly("h_hiv_deaths_no_art", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double, false>::h_hiv_deaths_no_art)
+        .def_readonly("p_infections", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double, false>::p_infections)
+        .def_readonly("h_hiv_deaths_art", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double, false>::h_hiv_deaths_art)
+        .def_readonly("h_art_initiation", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double, false>::h_art_initiation)
+        .def_readonly("p_hiv_deaths", &leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double, false>::p_hiv_deaths);
 
-    py::class_<leapfrog::ChildModelState<leapfrog::BaseModelFullAgeStratification, double>>(m, "ChildModelState")
+    py::class_<leapfrog::ChildModelState<leapfrog::BaseModelFullAgeStratification, double, false>>(m, "ChildModelState")
         .def(py::init<const leapfrog::Parameters<leapfrog::BaseModelFullAgeStratification, double>&>())
-        .def("reset", &leapfrog::ChildModelState<leapfrog::BaseModelFullAgeStratification, double>::reset);
+        .def("reset", &leapfrog::ChildModelState<leapfrog::BaseModelFullAgeStratification, double, false>::reset);
 
-    py::class_<leapfrog::State<leapfrog::BaseModelFullAgeStratification, double>>(m, "State")
-        .def(py::init<const leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double>&,
-                      const leapfrog::ChildModelState<leapfrog::BaseModelFullAgeStratification, double>&>())
-        .def(py::init<const leapfrog::Parameters<leapfrog::BaseModelFullAgeStratification, double>&>())
-        .def("reset", &leapfrog::State<leapfrog::BaseModelFullAgeStratification, double>::reset)
-        .def_readonly("base", &leapfrog::State<leapfrog::BaseModelFullAgeStratification, double>::base)
-        .def_readonly("children", &leapfrog::State<leapfrog::BaseModelFullAgeStratification, double>::children);
+    py::class_<leapfrog::State<leapfrog::BaseModelFullAgeStratification, double, false>>(m, "State")
+        .def(py::init<const leapfrog::BaseModelState<leapfrog::BaseModelFullAgeStratification, double, false>&,
+                      const leapfrog::ChildModelState<leapfrog::BaseModelFullAgeStratification, double, false>&>())
+        .def("reset", &leapfrog::State<leapfrog::BaseModelFullAgeStratification, double, false>::reset)
+        .def_readonly("base", &leapfrog::State<leapfrog::BaseModelFullAgeStratification, double, false>::base)
+        .def_readonly("children", &leapfrog::State<leapfrog::BaseModelFullAgeStratification, double, false>::children);
 
     m.def(
         "project_single_year_cpp",
-        &leapfrog::project_single_year<leapfrog::BaseModelFullAgeStratification, double>,
+        &leapfrog::project_single_year<leapfrog::BaseModelFullAgeStratification, double, false>,
         py::arg("time_step"),
         py::arg("pars"),
         py::arg("state_curr"),
@@ -244,18 +241,18 @@ PYBIND11_MODULE(leapfrog, m) {
 
     m.def(
         "set_initial_state_cpp",
-        &leapfrog::set_initial_state<leapfrog::BaseModelFullAgeStratification, double>,
+        &leapfrog::set_initial_state<leapfrog::BaseModelFullAgeStratification, double, false>,
         py::arg("state"),
         py::arg("pars"),
         "Set initial state from the parameters"
     );
 
-    m.def(
-        "run_model_cpp",
-        &leapfrog::simulate_model<leapfrog::BaseModelFullAgeStratification, double>,
-        py::arg("params"),
-        py::arg("proj_years"),
-        py::arg("save_steps"),
-        "Run a simulation model over a specified number of time steps"
-    );
+     m.def(
+         "run_model_cpp",
+         &leapfrog::simulate_model<leapfrog::BaseModelFullAgeStratification, double>,
+         py::arg("params"),
+         py::arg("proj_years"),
+         py::arg("save_steps"),
+         "Run a simulation model over a specified number of time steps"
+     );
 }

--- a/leapfrog-py/src/leapfrog_py/leapfrog_py.py
+++ b/leapfrog-py/src/leapfrog_py/leapfrog_py.py
@@ -26,7 +26,6 @@ def set_initial_state(
     params = _initialise_params(parameters, 10)
     initial_state = _initialise_state(0, state, params)
     set_initial_state_cpp(initial_state, params)
-    _write_state(0, initial_state, state)
 
 
 def project_single_year(
@@ -46,8 +45,6 @@ def project_single_year(
     state_now = _initialise_state(i, state, params)
 
     project_single_year_cpp(i, params, state_prev, state_now)
-
-    _write_state(i, state_now, state)
 
 
 def run_leapfrog(
@@ -130,20 +127,20 @@ def _initialise_params(
 def _initialise_state(
     time_step: int, state: dict[str, np.ndarray], params
 ) -> State:
-    state = {k: v[..., time_step] for k, v in state.items()}
+    year_state = {k: np.atleast_1d(v[..., time_step]) for k, v in state.items()}
     base_model_state = BaseModelState(
-        p_total_pop=state["p_total_pop"],
-        births=state["births"].item(),
-        p_total_pop_natural_deaths=state["p_total_pop_natural_deaths"],
-        p_hiv_pop=state["p_hiv_pop"],
-        p_hiv_pop_natural_deaths=state["p_hiv_pop_natural_deaths"],
-        h_hiv_adult=state["h_hiv_adult"],
-        h_art_adult=state["h_art_adult"],
-        h_hiv_deaths_no_art=state["h_hiv_deaths_no_art"],
-        p_infections=state["p_infections"],
-        h_hiv_deaths_art=state["h_hiv_deaths_art"],
-        h_art_initiation=state["h_art_initiation"],
-        p_hiv_deaths=state["p_hiv_deaths"],
+        p_total_pop=year_state["p_total_pop"],
+        births=year_state["births"],
+        p_total_pop_natural_deaths=year_state["p_total_pop_natural_deaths"],
+        p_hiv_pop=year_state["p_hiv_pop"],
+        p_hiv_pop_natural_deaths=year_state["p_hiv_pop_natural_deaths"],
+        h_hiv_adult=year_state["h_hiv_adult"],
+        h_art_adult=year_state["h_art_adult"],
+        h_hiv_deaths_no_art=year_state["h_hiv_deaths_no_art"],
+        p_infections=year_state["p_infections"],
+        h_hiv_deaths_art=year_state["h_hiv_deaths_art"],
+        h_art_initiation=year_state["h_art_initiation"],
+        p_hiv_deaths=year_state["p_hiv_deaths"],
     )
     # TODO: Initialise child model state from the data, and remove params from the function signature
     return State(base_model_state, ChildModelState(params))

--- a/leapfrog-py/src/leapfrog_py/leapfrog_py.py
+++ b/leapfrog-py/src/leapfrog_py/leapfrog_py.py
@@ -144,28 +144,3 @@ def _initialise_state(
     )
     # TODO: Initialise child model state from the data, and remove params from the function signature
     return State(base_model_state, ChildModelState(params))
-
-
-def _write_state(
-    time_step: int, state: State, full_state: dict[str, np.ndarray]
-):
-    # TODO: Code generate this, possibly on the C++ side. But hopefully it will be obsolete if we can
-    # pass in a numpy view of the state by reference, to make this copying unnecessary.
-    full_state["p_total_pop"][..., time_step] = state.base.p_total_pop
-    full_state["births"][..., time_step] = state.base.births
-    full_state["p_total_pop_natural_deaths"][
-        ..., time_step
-    ] = state.base.p_total_pop_natural_deaths
-    full_state["p_hiv_pop"][..., time_step] = state.base.p_hiv_pop
-    full_state["p_hiv_pop_natural_deaths"][
-        ..., time_step
-    ] = state.base.p_hiv_pop_natural_deaths
-    full_state["h_hiv_adult"][..., time_step] = state.base.h_hiv_adult
-    full_state["h_art_adult"][..., time_step] = state.base.h_art_adult
-    full_state["h_hiv_deaths_no_art"][
-        ..., time_step
-    ] = state.base.h_hiv_deaths_no_art
-    full_state["p_infections"][..., time_step] = state.base.p_infections
-    full_state["h_hiv_deaths_art"][..., time_step] = state.base.h_hiv_deaths_art
-    full_state["h_art_initiation"][..., time_step] = state.base.h_art_initiation
-    full_state["p_hiv_deaths"][..., time_step] = state.base.p_hiv_deaths

--- a/vignettes/development.Rmd
+++ b/vignettes/development.Rmd
@@ -31,11 +31,11 @@ All model functions are templated on the model variant, and any conditional beha
 All model functions should have the same signature e.g.
 
 ```
-template<typename ModelVariant, typename real_type>
+template<typename ModelVariant, typename real_type, bool OwnedData>
 void my_model_function(int time_step,
                        const Parameters<ModelVariant, real_type> &pars,
-                       const State<ModelVariant, real_type> &state_curr,
-                       State<ModelVariant, real_type> &state_next,
+                       const State<ModelVariant, real_type, OwnedData> &state_curr,
+                       State<ModelVariant, real_type, OwnedData> &state_next,
                        IntermediateData<ModelVariant, real_type> &intermediate) {
 ```
 


### PR DESCRIPTION
Fixes #55 and builds on #59, should be reviewed after that

This PR will
* Add a new template arg to State types so that they can either own data i.e. use TensorFixedSize types, or they can hold references to data owned elsewhere i.e. TensorMap<TensorFixedSize> types. We want this because from Python we have a large numpy array with a time dimension. I want to take a view of this at time `t - 1` and `t`, and pass these in as `state` and `state_next`. Where `state` will be used by reference readonly and `state_next` will be written to. 
* Add a script to benchmark to the python fit

Benchmark with state owning the memory (before this PR)
```
❯ ./benchmark.py
Full model benchmark
Minimum Time: 16.5 ms
Median Time: 19.3 ms
Maximum Time: 24.3 ms
Number of Iterations: 50
Total Time: 980.6 ms

Year by year benchmark
Minimum Time: 18.6 ms
Median Time: 19.4 ms
Maximum Time: 22.9 ms
Number of Iterations: 50
Total Time: 987.2 ms
```

Passing State by reference (after this PR)
```
❯ ./scripts/benchmark.py
Full model benchmark
Minimum Time: 16.2 ms
Median Time: 19.5 ms
Maximum Time: 22.8 ms
Number of Iterations: 50
Total Time: 980.5 ms

Year by year benchmark
Minimum Time: 15.2 ms
Median Time: 15.7 ms
Maximum Time: 17.6 ms
Number of Iterations: 50
Total Time: 799.2 ms
```
