### PR TITLE
Remove owned data flag for now

### DIFF
--- a/inst/include/child_model_simulation.hpp
+++ b/inst/include/child_model_simulation.hpp
@@ -6,11 +6,11 @@ namespace leapfrog {
 
 namespace internal {
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_child_ageing(int t,
                       const Parameters<ModelVariant, real_type> &pars,
-                      const State<ModelVariant, real_type, OwnedData> &state_curr,
-                      State<ModelVariant, real_type, OwnedData> &state_next,
+                      const State<ModelVariant, real_type> &state_curr,
+                      State<ModelVariant, real_type> &state_next,
                       IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "run_hiv_child_infections can only be called for model variants where run_child_model is true");
@@ -71,11 +71,11 @@ void run_child_ageing(int t,
 
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_wlhiv_births(int t,
                       const Parameters<ModelVariant, real_type> &pars,
-                      const State<ModelVariant, real_type, OwnedData> &state_curr,
-                      State<ModelVariant, real_type, OwnedData> &state_next,
+                      const State<ModelVariant, real_type> &state_curr,
+                      State<ModelVariant, real_type> &state_next,
                       IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "run_wlhiv_births can only be called for model variants where run_child_model is true");
@@ -151,28 +151,28 @@ void run_wlhiv_births(int t,
       i_hc.births_HE_15_24 += i_hc.birthsCurrAge;
     }
   } // end a
-  n_hc.hiv_births(0) = i_hc.birthsHE;
+  n_hc.hiv_births = i_hc.birthsHE;
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_wlhiv_births_input_mat_prev(int t,
                                      const Parameters<ModelVariant, real_type> &pars,
-                                     const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                     State<ModelVariant, real_type, OwnedData> &state_next,
+                                     const State<ModelVariant, real_type> &state_curr,
+                                     State<ModelVariant, real_type> &state_next,
                                      IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "run_wlhiv_births_input_mat_prev can only be called for model variants where run_child_model is true");
   const auto& p_hc = pars.children.children;
   auto& n_hc = state_next.children;
 
-  n_hc.hiv_births(0) = p_hc.mat_hiv_births(t);
+  n_hc.hiv_births = p_hc.mat_hiv_births(t);
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void calc_hiv_negative_pop(int t,
                            const Parameters<ModelVariant, real_type> &pars,
-                           const State<ModelVariant, real_type, OwnedData> &state_curr,
-                           State<ModelVariant, real_type, OwnedData> &state_next,
+                           const State<ModelVariant, real_type> &state_curr,
+                           State<ModelVariant, real_type> &state_next,
                            IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "calc_hiv_negative_pop can only be called for model variants where run_child_model is true");
@@ -189,11 +189,11 @@ void calc_hiv_negative_pop(int t,
   }// end s
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void adjust_hiv_births(int t,
                        const Parameters<ModelVariant, real_type> &pars,
-                       const State<ModelVariant, real_type, OwnedData> &state_curr,
-                       State<ModelVariant, real_type, OwnedData> &state_next,
+                       const State<ModelVariant, real_type> &state_curr,
+                       State<ModelVariant, real_type> &state_next,
                        IntermediateData<ModelVariant, real_type> &intermediate) {
   const auto cpars = pars.children.children;
   static_assert(ModelVariant::run_child_model,
@@ -202,17 +202,17 @@ void adjust_hiv_births(int t,
   auto& n_hc = state_next.children;
 
   if (p_hc.abortion(t, 1) == 1) {
-    n_hc.hiv_births(0) -= n_hc.hiv_births(0) * p_hc.abortion(t, 0);
+    n_hc.hiv_births -= n_hc.hiv_births * p_hc.abortion(t, 0);
   } else {
-    n_hc.hiv_births(0) -=  p_hc.abortion(t, 0);
+    n_hc.hiv_births -=  p_hc.abortion(t, 0);
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void convert_PMTCT_num_to_perc(int t,
                                const Parameters<ModelVariant, real_type> &pars,
-                               const State<ModelVariant, real_type, OwnedData> &state_curr,
-                               State<ModelVariant, real_type, OwnedData> &state_next,
+                               const State<ModelVariant, real_type> &state_curr,
+                               State<ModelVariant, real_type> &state_next,
                                IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "convert_PMTCT_num_to_perc can only be called for model variants where run_child_model is true");
@@ -226,7 +226,7 @@ void convert_PMTCT_num_to_perc(int t,
     i_hc.sumARV += p_hc.PMTCT(hp, t);
   }
 
-  i_hc.need_PMTCT = std::max(i_hc.sumARV, n_hc.hiv_births(0));
+  i_hc.need_PMTCT = std::max(i_hc.sumARV, n_hc.hiv_births);
 
   i_hc.OnPMTCT = i_hc.sumARV + p_hc.patients_reallocated(t);
   i_hc.OnPMTCT = std::min(i_hc.OnPMTCT, i_hc.need_PMTCT);
@@ -252,11 +252,11 @@ void convert_PMTCT_num_to_perc(int t,
   i_hc.PMTCT_coverage(5) = i_hc.PMTCT_coverage(5) * p_hc.PMTCT_dropout(1, t);
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void convert_PMTCT_pre_bf(int t,
                           const Parameters<ModelVariant, real_type> &pars,
-                          const State<ModelVariant, real_type, OwnedData> &state_curr,
-                          State<ModelVariant, real_type, OwnedData> &state_next,
+                          const State<ModelVariant, real_type> &state_curr,
+                          State<ModelVariant, real_type> &state_next,
                           IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "convert_PMTCT_num_to_perc can only be called for model variants where run_child_model is true");
@@ -270,11 +270,11 @@ void convert_PMTCT_pre_bf(int t,
   } // end hPS
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void calc_wlhiv_cd4_proportion(int t,
                                const Parameters<ModelVariant, real_type> &pars,
-                               const State<ModelVariant, real_type, OwnedData> &state_curr,
-                               State<ModelVariant, real_type, OwnedData> &state_next,
+                               const State<ModelVariant, real_type> &state_curr,
+                               State<ModelVariant, real_type> &state_next,
                                IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "calc_wlhiv_cd4_proportion can only be called for model variants where run_child_model is true");
@@ -322,11 +322,11 @@ void calc_wlhiv_cd4_proportion(int t,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void adjust_option_A_B_tr(int t,
                           const Parameters<ModelVariant, real_type> &pars,
-                          const State<ModelVariant, real_type, OwnedData> &state_curr,
-                          State<ModelVariant, real_type, OwnedData> &state_next,
+                          const State<ModelVariant, real_type> &state_curr,
+                          State<ModelVariant, real_type> &state_next,
                           IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "adjust_option_A_B_tr can only be called for model variants where run_child_model is true");
@@ -354,11 +354,11 @@ void adjust_option_A_B_tr(int t,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void adjust_option_A_B_bf_tr(int t,
                              const Parameters<ModelVariant, real_type> &pars,
-                             const State<ModelVariant, real_type, OwnedData> &state_curr,
-                             State<ModelVariant, real_type, OwnedData> &state_next,
+                             const State<ModelVariant, real_type> &state_curr,
+                             State<ModelVariant, real_type> &state_next,
                              IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "adjust_option_A_B_bf_tr can only be called for model variants where run_child_model is true");
@@ -389,11 +389,11 @@ void adjust_option_A_B_bf_tr(int t,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void maternal_incidence_in_pregnancy_tr(int t,
                                         const Parameters<ModelVariant, real_type> &pars,
-                                        const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                        State<ModelVariant, real_type, OwnedData> &state_next,
+                                        const State<ModelVariant, real_type> &state_curr,
+                                        State<ModelVariant, real_type> &state_next,
                                         IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "maternal_incidence_in_pregnancy_tr can only be called for model variants where run_child_model is true");
@@ -438,7 +438,7 @@ void maternal_incidence_in_pregnancy_tr(int t,
       i_hc.incidence_rate_wlhiv = i_hc.age_weighted_infections / i_hc.age_weighted_hivneg;
       //0.75 is 9/12, gestational period, index 7 in the vertical trasnmission object is the index for maternal seroconversion
       i_hc.perinatal_transmission_from_incidence = i_hc.incidence_rate_wlhiv * 0.75 *
-                                                   (n_da.births(0) - i_hc.need_PMTCT) *
+                                                   (n_da.births - i_hc.need_PMTCT) *
                                                    p_hc.vertical_transmission_rate(7, 0);
     } else {
       i_hc.incidence_rate_wlhiv = 0.0;
@@ -447,11 +447,11 @@ void maternal_incidence_in_pregnancy_tr(int t,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void perinatal_tr(int t,
                   const Parameters<ModelVariant, real_type> &pars,
-                  const State<ModelVariant, real_type, OwnedData> &state_curr,
-                  State<ModelVariant, real_type, OwnedData> &state_next,
+                  const State<ModelVariant, real_type> &state_curr,
+                  State<ModelVariant, real_type> &state_next,
                   IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "perinatal_tr can only be called for model variants where run_child_model is true");
@@ -459,7 +459,7 @@ void perinatal_tr(int t,
   auto& n_da = state_next.dp;
   auto& i_hc = intermediate.children;
 
-  i_hc.births_sum = n_da.births(0);
+  i_hc.births_sum = n_da.births;
 
   // TODO: add in patients reallocated
   internal::convert_PMTCT_num_to_perc(t, pars, state_curr, state_next, intermediate);
@@ -504,11 +504,11 @@ void perinatal_tr(int t,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void maternal_incidence_in_bf_tr(int t,
                                  const Parameters<ModelVariant, real_type> &pars,
-                                 const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                 State<ModelVariant, real_type, OwnedData> &state_next,
+                                 const State<ModelVariant, real_type> &state_curr,
+                                 State<ModelVariant, real_type> &state_next,
                                  IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "maternal_incidence_in_bf_tr can only be called for model variants where run_child_model is true");
@@ -523,11 +523,11 @@ void maternal_incidence_in_bf_tr(int t,
    i_hc.bf_incident_hiv_transmission_rate = i_hc.bf_at_risk * p_hc.vertical_transmission_rate(7, 1);
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_bf_transmission_rate(int t,
                               const Parameters<ModelVariant, real_type> &pars,
-                              const State<ModelVariant, real_type, OwnedData> &state_curr,
-                              State<ModelVariant, real_type, OwnedData> &state_next,
+                              const State<ModelVariant, real_type> &state_curr,
+                              State<ModelVariant, real_type> &state_next,
                               IntermediateData<ModelVariant, real_type> &intermediate,
                               int bf_start, int bf_end, int index) {
   static_assert(ModelVariant::run_child_model,
@@ -639,11 +639,11 @@ void run_bf_transmission_rate(int t,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void nosocomial_infections(int t,
                            const Parameters<ModelVariant, real_type> &pars,
-                           const State<ModelVariant, real_type, OwnedData> &state_curr,
-                           State<ModelVariant, real_type, OwnedData> &state_next,
+                           const State<ModelVariant, real_type> &state_curr,
+                           State<ModelVariant, real_type> &state_next,
                            IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "nosocomial_infections can only be called for model variants where run_child_model is true");
@@ -667,11 +667,11 @@ void nosocomial_infections(int t,
   } // end NS
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void add_infections(int t,
                     const Parameters<ModelVariant, real_type> &pars,
-                    const State<ModelVariant, real_type, OwnedData> &state_curr,
-                    State<ModelVariant, real_type, OwnedData> &state_next,
+                    const State<ModelVariant, real_type> &state_curr,
+                    State<ModelVariant, real_type> &state_next,
                     IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "add_infections can only be called for model variants where run_child_model is true");
@@ -684,11 +684,11 @@ void add_infections(int t,
   auto& n_hc = state_next.children;
   auto& i_hc = intermediate.children;
 
-  if (n_hc.hiv_births(0) > 0) {
+  if (n_hc.hiv_births > 0) {
     internal::perinatal_tr(t, pars, state_curr, state_next, intermediate);
 
     // Perinatal transmission
-    auto perinatal_transmission_births = n_hc.hiv_births(0) * i_hc.perinatal_transmission_rate;
+    auto perinatal_transmission_births = n_hc.hiv_births * i_hc.perinatal_transmission_rate;
     for (int s = 0; s < ss_d.NS; ++s) {
       for (int hd = 0; hd < ss_c.hc1DS; ++hd) {
         if (s == 0) {
@@ -715,15 +715,15 @@ void add_infections(int t,
     if (p_hc.mat_prev_input(t)) {
       total_births = p_hc.total_births(t);
     } else {
-      total_births = n_dp.births(0);
+      total_births = n_dp.births;
     }
 
     // 0-6
     for (int s = 0; s < ss_d.NS; ++s) {
-      auto bf_hiv_by_sex = n_hc.hiv_births(0) * p_dm.births_sex_prop(s, t) *
+      auto bf_hiv_by_sex = n_hc.hiv_births * p_dm.births_sex_prop(s, t) *
                            i_hc.bf_transmission_rate(0);
       // vertical infection from maternal infection during breastfeeding
-      bf_hiv_by_sex += (total_births - n_hc.hiv_births(0)) * p_dm.births_sex_prop(s, t) *
+      bf_hiv_by_sex += (total_births - n_hc.hiv_births) * p_dm.births_sex_prop(s, t) *
                        i_hc.bf_incident_hiv_transmission_rate;
       for (int hd = 0; hd < ss_c.hc1DS; ++hd) {
         n_hc.hc1_hiv_pop(hd, 1, 0, s) += p_hc.hc1_cd4_dist(hd) * bf_hiv_by_sex;
@@ -735,7 +735,7 @@ void add_infections(int t,
     // 6-12
     internal::run_bf_transmission_rate(t, pars, state_curr, state_next, intermediate, 3, 6, 1);
     for (int s = 0; s < ss_d.NS; ++s) {
-      auto bf_hiv_by_sex = n_hc.hiv_births(0) * p_dm.births_sex_prop(s, t) * i_hc.bf_transmission_rate(1);
+      auto bf_hiv_by_sex = n_hc.hiv_births * p_dm.births_sex_prop(s, t) * i_hc.bf_transmission_rate(1);
       for (int hd = 0; hd < ss_c.hc1DS; ++hd) {
         n_hc.hc1_hiv_pop(hd, 2, 0, s) += p_hc.hc1_cd4_dist(hd) * bf_hiv_by_sex;
       } // end hc1DS
@@ -751,8 +751,8 @@ void add_infections(int t,
                                    (n_dp.p_total_pop(1, 0) - n_ha.p_hiv_pop(1, 0) + n_dp.p_total_pop(1, 1) - n_ha.p_hiv_pop(1, 1));
       auto uninfected_prop_24_plus = (n_dp.p_total_pop(2, s) - n_ha.p_hiv_pop(2, s)) /
                                      (n_dp.p_total_pop(2, 0) - n_ha.p_hiv_pop(2, 0) + n_dp.p_total_pop(2, 1) - n_ha.p_hiv_pop(2, 1));
-      auto bf_hiv_transmission_12_24 = n_hc.hiv_births(0) * i_hc.bf_transmission_rate(2) * uninfected_prop_12_24;
-      auto bf_hiv_transmission_24_plus = n_hc.hiv_births(0) * i_hc.bf_transmission_rate(3) * uninfected_prop_24_plus;
+      auto bf_hiv_transmission_12_24 = n_hc.hiv_births * i_hc.bf_transmission_rate(2) * uninfected_prop_12_24;
+      auto bf_hiv_transmission_24_plus = n_hc.hiv_births * i_hc.bf_transmission_rate(3) * uninfected_prop_24_plus;
       for (int hd = 0; hd < ss_c.hc1DS; ++hd) {
         // 12-24
         n_hc.hc1_hiv_pop(hd, 3, 1, s) += p_hc.hc1_cd4_dist(hd) * bf_hiv_transmission_12_24;
@@ -773,11 +773,11 @@ void add_infections(int t,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void need_for_cotrim(int t,
                      const Parameters<ModelVariant, real_type> &pars,
-                     const State<ModelVariant, real_type, OwnedData> &state_curr,
-                     State<ModelVariant, real_type, OwnedData> &state_next,
+                     const State<ModelVariant, real_type> &state_curr,
+                     State<ModelVariant, real_type> &state_next,
                      IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "need_for_cotrim can only be called for model variants where run_child_model is true");
@@ -821,17 +821,17 @@ void need_for_cotrim(int t,
   } // end ss_d.NS
 
   // Births from the last 18 months are eligible
-  n_hc.ctx_need(0) = n_hc.hiv_births(0) * 1.5;
+  n_hc.ctx_need = n_hc.hiv_births * 1.5;
   for (int s = 0; s < ss_d.NS; ++s) {
     for (int a = 1; a < p_op.p_idx_fertility_first; ++a) {
       for (int cat = 0; cat < ss_c.hcTT; ++cat) {
         for (int hd = 0; hd < ss_c.hc1DS; ++hd) {
           if (a == 1) {
-            n_hc.ctx_need(0) += n_hc.hc1_hiv_pop(hd, cat, a, s) * 0.5;
+            n_hc.ctx_need += n_hc.hc1_hiv_pop(hd, cat, a, s) * 0.5;
           } else if (a < ss_c.hc2_agestart) {
-            n_hc.ctx_need(0) += n_hc.hc1_hiv_pop(hd, cat, a, s);
+            n_hc.ctx_need += n_hc.hc1_hiv_pop(hd, cat, a, s);
           } else if (hd < ss_c.hc2DS) {
-            n_hc.ctx_need(0) += i_hc.hc_ctx_need(hd, cat, a, s);
+            n_hc.ctx_need += i_hc.hc_ctx_need(hd, cat, a, s);
           }
         }
       }
@@ -839,11 +839,11 @@ void need_for_cotrim(int t,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void cotrim_need_coverage(int t,
                           const Parameters<ModelVariant, real_type> &pars,
-                          const State<ModelVariant, real_type, OwnedData> &state_curr,
-                          State<ModelVariant, real_type, OwnedData> &state_next,
+                          const State<ModelVariant, real_type> &state_curr,
+                          State<ModelVariant, real_type> &state_next,
                           IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "cotrim_need_coverage can only be called for model variants where run_child_model is true");
@@ -853,21 +853,21 @@ void cotrim_need_coverage(int t,
   internal::need_for_cotrim(t, pars, state_curr, state_next, intermediate);
 
   if (p_hc.ctx_val_is_percent(t)) {
-    n_hc.ctx_mean(0) = p_hc.ctx_val(t - 1);
-    n_hc.ctx_mean(0) = (1 - p_hc.ctx_effect) * n_hc.ctx_mean(0) + (1 - n_hc.ctx_mean(0));
+    n_hc.ctx_mean = p_hc.ctx_val(t - 1);
+    n_hc.ctx_mean = (1 - p_hc.ctx_effect) * n_hc.ctx_mean + (1 - n_hc.ctx_mean);
   } else {
-    if (n_hc.ctx_need(0) > 0) {
-      n_hc.ctx_mean(0) = p_hc.ctx_val(t - 1) / n_hc.ctx_need(0);
-      n_hc.ctx_mean(0) = (1 - p_hc.ctx_effect) * n_hc.ctx_mean(0) + (1 - n_hc.ctx_mean(0));
+    if (n_hc.ctx_need > 0) {
+      n_hc.ctx_mean = p_hc.ctx_val(t - 1) / n_hc.ctx_need;
+      n_hc.ctx_mean = (1 - p_hc.ctx_effect) * n_hc.ctx_mean + (1 - n_hc.ctx_mean);
     }
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void cd4_mortality(int t,
                    const Parameters<ModelVariant, real_type> &pars,
-                   const State<ModelVariant, real_type, OwnedData> &state_curr,
-                   State<ModelVariant, real_type, OwnedData> &state_next,
+                   const State<ModelVariant, real_type> &state_curr,
+                   State<ModelVariant, real_type> &state_next,
                    IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "cd4_mortality can only be called for model variants where run_child_model is true");
@@ -883,7 +883,7 @@ void cd4_mortality(int t,
     for (int a = 0; a < ss_c.hc2_agestart; ++a) {
       for (int cat = 0; cat < ss_c.hcTT; ++cat) {
         for (int hd = 0; hd < ss_c.hc1DS; ++hd) {
-          auto hiv_deaths_strat = n_hc.ctx_mean(0) * n_hc.hc1_hiv_pop(hd, cat, a, s) * p_hc.hc1_cd4_mort(hd, cat, a);
+          auto hiv_deaths_strat = n_hc.ctx_mean * n_hc.hc1_hiv_pop(hd, cat, a, s) * p_hc.hc1_cd4_mort(hd, cat, a);
           i_hc.hc_posthivmort(hd, cat, a, s) = n_hc.hc1_hiv_pop(hd, cat, a, s) - hiv_deaths_strat;
         }
       }
@@ -894,7 +894,7 @@ void cd4_mortality(int t,
     for (int a = ss_c.hc2_agestart; a < p_op.p_idx_fertility_first; ++a) {
       for (int cat = 0; cat < ss_c.hcTT; ++cat) {
         for (int hd = 0; hd < ss_c.hc2DS; ++hd) {
-          auto hiv_deaths_strat = n_hc.ctx_mean(0) * n_hc.hc2_hiv_pop(hd, cat, a - ss_c.hc2_agestart, s) *
+          auto hiv_deaths_strat = n_hc.ctx_mean * n_hc.hc2_hiv_pop(hd, cat, a - ss_c.hc2_agestart, s) *
                                   p_hc.hc2_cd4_mort(hd, cat, a - ss_c.hc2_agestart);
           i_hc.hc_posthivmort(hd, cat, a, s) = n_hc.hc2_hiv_pop(hd, cat, a - ss_c.hc2_agestart, s) -
                                                hiv_deaths_strat;
@@ -935,11 +935,11 @@ void cd4_mortality(int t,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_child_hiv_mort(int t,
                         const Parameters<ModelVariant, real_type> &pars,
-                        const State<ModelVariant, real_type, OwnedData> &state_curr,
-                        State<ModelVariant, real_type, OwnedData> &state_next,
+                        const State<ModelVariant, real_type> &state_curr,
+                        State<ModelVariant, real_type> &state_next,
                         IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "run_child_hiv_mort can only be called for model variants where run_child_model is true");
@@ -954,7 +954,7 @@ void run_child_hiv_mort(int t,
     for (int a = 0; a < ss_c.hc2_agestart; ++a) {
       for (int cat = 0; cat < ss_c.hcTT; ++cat) {
         for (int hd = 0; hd < ss_c.hc1DS; ++hd) {
-          auto cd4_deaths_grad = n_hc.ctx_mean(0) * n_hc.hc1_hiv_pop(hd, cat, a, s) *
+          auto cd4_deaths_grad = n_hc.ctx_mean * n_hc.hc1_hiv_pop(hd, cat, a, s) *
                                  p_hc.hc1_cd4_mort(hd, cat, a);
           i_hc.hc_grad(hd, cat, a, s) -= cd4_deaths_grad;
           n_hc.hc1_noart_aids_deaths(hd, cat, a, s) += cd4_deaths_grad;
@@ -967,7 +967,7 @@ void run_child_hiv_mort(int t,
     for (int a = ss_c.hc2_agestart; a < p_op.p_idx_fertility_first; ++a) {
       for (int cat = 0; cat < ss_c.hcTT; ++cat) {
         for (int hd = 0; hd < ss_c.hc2DS; ++hd) {
-          auto cd4_mort_grad = n_hc.ctx_mean(0) *
+          auto cd4_mort_grad = n_hc.ctx_mean *
                                n_hc.hc2_hiv_pop(hd, cat, a - ss_c.hc2_agestart, s) *
                                p_hc.hc2_cd4_mort(hd, cat, a - ss_c.hc2_agestart);
           i_hc.hc_grad(hd, cat, a, s) -= cd4_mort_grad;
@@ -978,11 +978,11 @@ void run_child_hiv_mort(int t,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void add_child_grad(int t,
                     const Parameters<ModelVariant, real_type> &pars,
-                    const State<ModelVariant, real_type, OwnedData> &state_curr,
-                    State<ModelVariant, real_type, OwnedData> &state_next,
+                    const State<ModelVariant, real_type> &state_curr,
+                    State<ModelVariant, real_type> &state_next,
                     IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "add_child_grad can only be called for model variants where run_child_model is true");
@@ -1013,11 +1013,11 @@ void add_child_grad(int t,
   } // end s
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void art_eligibility_by_age(int t,
                             const Parameters<ModelVariant, real_type> &pars,
-                            const State<ModelVariant, real_type, OwnedData> &state_curr,
-                            State<ModelVariant, real_type, OwnedData> &state_next,
+                            const State<ModelVariant, real_type> &state_curr,
+                            State<ModelVariant, real_type> &state_next,
                             IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "art_eligibility_by_age can only be called for model variants where run_child_model is true");
@@ -1042,11 +1042,11 @@ void art_eligibility_by_age(int t,
   } // end ss_d.NS
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void art_eligibility_by_cd4(int t,
                             const Parameters<ModelVariant, real_type> &pars,
-                            const State<ModelVariant, real_type, OwnedData> &state_curr,
-                            State<ModelVariant, real_type, OwnedData> &state_next,
+                            const State<ModelVariant, real_type> &state_curr,
+                            State<ModelVariant, real_type> &state_next,
                             IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "art_eligibility_by_cd4 can only be called for model variants where run_child_model is true");
@@ -1073,11 +1073,11 @@ void art_eligibility_by_cd4(int t,
   } // end ss.NS
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void eligible_for_treatment(int t,
                             const Parameters<ModelVariant, real_type> &pars,
-                            const State<ModelVariant, real_type, OwnedData> &state_curr,
-                            State<ModelVariant, real_type, OwnedData> &state_next,
+                            const State<ModelVariant, real_type> &state_curr,
+                            State<ModelVariant, real_type> &state_next,
                             IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "eligible_for_treatment can only be called for model variants where run_child_model is true");
@@ -1101,11 +1101,11 @@ void eligible_for_treatment(int t,
   } // end ss_d.NS
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void on_art_mortality(int t,
                      const Parameters<ModelVariant, real_type> &pars,
-                     const State<ModelVariant, real_type, OwnedData> &state_curr,
-                     State<ModelVariant, real_type, OwnedData> &state_next,
+                     const State<ModelVariant, real_type> &state_curr,
+                     State<ModelVariant, real_type> &state_next,
                      IntermediateData<ModelVariant, real_type> &intermediate,
                      int t_art_idx) {
   static_assert(ModelVariant::run_child_model,
@@ -1158,11 +1158,11 @@ void on_art_mortality(int t,
   } // end ss_d.NS
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void deaths_this_year(int t,
                       const Parameters<ModelVariant, real_type> &pars,
-                      const State<ModelVariant, real_type, OwnedData> &state_curr,
-                      State<ModelVariant, real_type, OwnedData> &state_next,
+                      const State<ModelVariant, real_type> &state_curr,
+                      State<ModelVariant, real_type> &state_next,
                       IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "deaths_this_year can only be called for model variants where run_child_model is true");
@@ -1190,11 +1190,11 @@ void deaths_this_year(int t,
   i_hc.hc_art_deaths(0) = i_hc.hc_art_deaths(1) + i_hc.hc_art_deaths(2) + i_hc.hc_art_deaths(3);
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void progress_time_on_art(int t,
                           const Parameters<ModelVariant, real_type> &pars,
-                          const State<ModelVariant, real_type, OwnedData> &state_curr,
-                          State<ModelVariant, real_type, OwnedData> &state_next,
+                          const State<ModelVariant, real_type> &state_curr,
+                          State<ModelVariant, real_type> &state_next,
                           IntermediateData<ModelVariant, real_type> &intermediate,
                           int curr_t_idx, int end_t_idx) {
   static_assert(ModelVariant::run_child_model,
@@ -1222,11 +1222,11 @@ void progress_time_on_art(int t,
   } // end ss_c.hc1DS
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void calc_total_and_unmet_art_need(int t,
                                    const Parameters<ModelVariant, real_type> &pars,
-                                   const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                   State<ModelVariant, real_type, OwnedData> &state_next,
+                                   const State<ModelVariant, real_type> &state_curr,
+                                   State<ModelVariant, real_type> &state_next,
                                    IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "calc_total_and_unmet_art_need can only be called for model variants where run_child_model is true");
@@ -1270,11 +1270,11 @@ void calc_total_and_unmet_art_need(int t,
   i_hc.total_need(0) = i_hc.on_art(0) + i_hc.unmet_need(0) + i_hc.hc_art_deaths(0);
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void age_specific_art_last_year(int t,
                                  const Parameters<ModelVariant, real_type> &pars,
-                                 const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                 State<ModelVariant, real_type, OwnedData> &state_next,
+                                 const State<ModelVariant, real_type> &state_curr,
+                                 State<ModelVariant, real_type> &state_next,
                                  IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "age_specific_art_last_year can only be called for model variants where run_child_model is true");
@@ -1318,11 +1318,11 @@ void age_specific_art_last_year(int t,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void art_last_year(int t,
                    const Parameters<ModelVariant, real_type> &pars,
-                   const State<ModelVariant, real_type, OwnedData> &state_curr,
-                   State<ModelVariant, real_type, OwnedData> &state_next,
+                   const State<ModelVariant, real_type> &state_curr,
+                   State<ModelVariant, real_type> &state_next,
                    IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "art_last_year can only be called for model variants where run_child_model is true");
@@ -1352,11 +1352,11 @@ void art_last_year(int t,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void art_this_year(int t,
                    const Parameters<ModelVariant, real_type> &pars,
-                   const State<ModelVariant, real_type, OwnedData> &state_curr,
-                   State<ModelVariant, real_type, OwnedData> &state_next,
+                   const State<ModelVariant, real_type> &state_curr,
+                   State<ModelVariant, real_type> &state_next,
                    IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "art_this_year can only be called for model variants where run_child_model is true");
@@ -1371,11 +1371,11 @@ void art_this_year(int t,
   } // end ag
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void calc_art_initiates(int t,
                         const Parameters<ModelVariant, real_type> &pars,
-                        const State<ModelVariant, real_type, OwnedData> &state_curr,
-                        State<ModelVariant, real_type, OwnedData> &state_next,
+                        const State<ModelVariant, real_type> &state_curr,
+                        State<ModelVariant, real_type> &state_next,
                         IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "calc_art_initiates can only be called for model variants where run_child_model is true");
@@ -1402,11 +1402,11 @@ void calc_art_initiates(int t,
   } // end ag
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void art_ltfu(int t,
               const Parameters<ModelVariant, real_type> &pars,
-              const State<ModelVariant, real_type, OwnedData> &state_curr,
-              State<ModelVariant, real_type, OwnedData> &state_next,
+              const State<ModelVariant, real_type> &state_curr,
+              State<ModelVariant, real_type> &state_next,
               IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "art_ltfu can only be called for model variants where run_child_model is true");
@@ -1472,11 +1472,11 @@ void art_ltfu(int t,
   } // end ss_d.NS
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void apply_ltfu_to_hivpop(int t,
                           const Parameters<ModelVariant, real_type> &pars,
-                          const State<ModelVariant, real_type, OwnedData> &state_curr,
-                          State<ModelVariant, real_type, OwnedData> &state_next,
+                          const State<ModelVariant, real_type> &state_curr,
+                          State<ModelVariant, real_type> &state_next,
                           IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "apply_ltfu_to_hivpop can only be called for model variants where run_child_model is true");
@@ -1501,11 +1501,11 @@ void apply_ltfu_to_hivpop(int t,
   } // end ss_d.NS
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void apply_ltfu_to_artpop(int t,
                           const Parameters<ModelVariant, real_type> &pars,
-                          const State<ModelVariant, real_type, OwnedData> &state_curr,
-                          State<ModelVariant, real_type, OwnedData> &state_next,
+                          const State<ModelVariant, real_type> &state_curr,
+                          State<ModelVariant, real_type> &state_next,
                           IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "apply_ltfu_to_artpop can only be called for model variants where run_child_model is true");
@@ -1531,11 +1531,11 @@ void apply_ltfu_to_artpop(int t,
   } // end ss_d.NS
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void art_initiation_by_age(int t,
                            const Parameters<ModelVariant, real_type> &pars,
-                           const State<ModelVariant, real_type, OwnedData> &state_curr,
-                           State<ModelVariant, real_type, OwnedData> &state_next,
+                           const State<ModelVariant, real_type> &state_curr,
+                           State<ModelVariant, real_type> &state_next,
                            IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "art_initiation_by_age can only be called for model variants where run_child_model is true");
@@ -1639,11 +1639,11 @@ void art_initiation_by_age(int t,
   } // end if
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void fill_total_pop_outputs(int t,
                             const Parameters<ModelVariant, real_type> &pars,
-                            const State<ModelVariant, real_type, OwnedData> &state_curr,
-                            State<ModelVariant, real_type, OwnedData> &state_next,
+                            const State<ModelVariant, real_type> &state_curr,
+                            State<ModelVariant, real_type> &state_next,
                             IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "fill_total_pop_outputs can only be called for model variants where run_child_model is true");
@@ -1681,11 +1681,11 @@ void fill_total_pop_outputs(int t,
 
 } // namespace internal
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_child_model_simulation(int t,
                                 const Parameters<ModelVariant, real_type> &pars,
-                                const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                State<ModelVariant, real_type, OwnedData> &state_next,
+                                const State<ModelVariant, real_type> &state_curr,
+                                State<ModelVariant, real_type> &state_next,
                                 internal::IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "run_child_model_simulation can only be called for model variants where run_child_model is true");

--- a/inst/include/frogger.hpp
+++ b/inst/include/frogger.hpp
@@ -12,8 +12,8 @@ namespace leapfrog {
 
 // If we want to set any state for first iteration to something
 // other than 0 do it here.
-template<typename ModelVariant, typename real_type, bool OwnedData>
-void set_initial_state(State<ModelVariant, real_type, OwnedData> &state,
+template<typename ModelVariant, typename real_type>
+void set_initial_state(State<ModelVariant, real_type> &state,
                        const Parameters<ModelVariant, real_type> &pars) {
   constexpr auto ss_d = StateSpace<ModelVariant>().dp;
   const auto& p_dm = pars.dp.demography;
@@ -41,9 +41,9 @@ OutputState<ModelVariant, real_type> run_model(int time_steps,
                                                const Parameters<ModelVariant, real_type> &pars) {
   const auto& p_op = pars.options;
 
-  auto state = State<ModelVariant, real_type, true>(pars);
+  auto state = State<ModelVariant, real_type>();
   auto state_next = state;
-  set_initial_state<ModelVariant, real_type, true>(state, pars);
+  set_initial_state<ModelVariant, real_type>(state, pars);
 
   internal::IntermediateData<ModelVariant, real_type> intermediate(p_op.hAG_15plus);
 

--- a/inst/include/general_demographic_projection.hpp
+++ b/inst/include/general_demographic_projection.hpp
@@ -7,11 +7,11 @@ namespace leapfrog {
 
 namespace internal {
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_ageing_and_mortality(int t,
                               const Parameters<ModelVariant, real_type> &pars,
-                              const State<ModelVariant, real_type, OwnedData> &state_curr,
-                              State<ModelVariant, real_type, OwnedData> &state_next,
+                              const State<ModelVariant, real_type> &state_curr,
+                              State<ModelVariant, real_type> &state_next,
                               IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss_d = StateSpace<ModelVariant>().dp;
   const auto& p_dm = pars.dp.demography;
@@ -33,11 +33,11 @@ void run_ageing_and_mortality(int t,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_migration(int t,
                    const Parameters<ModelVariant, real_type> &pars,
-                   const State<ModelVariant, real_type, OwnedData> &state_curr,
-                   State<ModelVariant, real_type, OwnedData> &state_next,
+                   const State<ModelVariant, real_type> &state_curr,
+                   State<ModelVariant, real_type> &state_next,
                    IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss_d = StateSpace<ModelVariant>().dp;
   const auto& p_dm = pars.dp.demography;
@@ -74,11 +74,11 @@ void run_migration(int t,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_fertility_and_infant_migration(int t,
                                         const Parameters<ModelVariant, real_type> &pars,
-                                        const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                        State<ModelVariant, real_type, OwnedData> &state_next,
+                                        const State<ModelVariant, real_type> &state_curr,
+                                        State<ModelVariant, real_type> &state_next,
                                         IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss = StateSpace<ModelVariant>().dp;
   const auto& p_dm = pars.dp.demography;
@@ -86,17 +86,16 @@ void run_fertility_and_infant_migration(int t,
   const auto& c_da = state_curr.dp;
   auto& n_da = state_next.dp;
 
-  // Births always length 1
-  n_da.births(0) = 0.0;
+  n_da.births = 0.0;
   for (int af = 0; af < p_op.p_fertility_age_groups; ++af) {
     auto total_female_pop_per_age_group = c_da.p_total_pop(p_op.p_idx_fertility_first + af, FEMALE) +
                                           n_da.p_total_pop(p_op.p_idx_fertility_first + af, FEMALE);
-    n_da.births(0) += total_female_pop_per_age_group * 0.5 * p_dm.age_specific_fertility_rate(af, t);
+    n_da.births += total_female_pop_per_age_group * 0.5 * p_dm.age_specific_fertility_rate(af, t);
   }
 
   // add births & infant migration
   for (int g = 0; g < ss.NS; ++g) {
-    real_type births_sex = n_da.births(0) * p_dm.births_sex_prop(g, t);
+    real_type births_sex = n_da.births * p_dm.births_sex_prop(g, t);
     n_da.p_total_pop_natural_deaths(0, g) = births_sex * (1.0 - p_dm.survival_probability(0, g, t));
     n_da.p_total_pop(0, g) = births_sex * p_dm.survival_probability(0, g, t);
 
@@ -114,11 +113,11 @@ void run_fertility_and_infant_migration(int t,
 }
 
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_general_pop_demographic_projection(int t,
                                             const Parameters<ModelVariant, real_type> &pars,
-                                            const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                            State<ModelVariant, real_type, OwnedData> &state_next,
+                                            const State<ModelVariant, real_type> &state_curr,
+                                            State<ModelVariant, real_type> &state_next,
                                             internal::IntermediateData<ModelVariant, real_type> &intermediate) {
   const auto& p_op = pars.options;
   internal::run_ageing_and_mortality<ModelVariant>(t, pars, state_curr, state_next, intermediate);
@@ -129,11 +128,11 @@ void run_general_pop_demographic_projection(int t,
 }
 
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_end_year_migration(int t,
                             const Parameters<ModelVariant, real_type> &pars,
-                            const State<ModelVariant, real_type, OwnedData> &state_curr,
-                            State<ModelVariant, real_type, OwnedData> &state_next,
+                            const State<ModelVariant, real_type> &state_curr,
+                            State<ModelVariant, real_type> &state_next,
                             internal::IntermediateData<ModelVariant, real_type> &intermediate) {
 
   constexpr auto ss_d = StateSpace<ModelVariant>().dp;

--- a/inst/include/generated/state_saver_types.hpp
+++ b/inst/include/generated/state_saver_types.hpp
@@ -237,7 +237,7 @@ struct ChildModelStateSaver {
 public:
   void save_state(ChildModelOutputState<ModelVariant, real_type> &full_state,
                   const size_t i,
-                  const State<ModelVariant, real_type, true> &state) {}
+                  const State<ModelVariant, real_type> &state) {}
 };
 
 template<typename ModelVariant, typename real_type>
@@ -245,9 +245,9 @@ struct DemographicProjectionStateSaver {
 public:
   void save_state(DemographicProjectionOutputState<ModelVariant, real_type> &output_state,
                   const size_t i,
-                  const State<ModelVariant, real_type, true> &state) {
+                  const State<ModelVariant, real_type> &state) {
     output_state.p_total_pop.chip(i, output_state.p_total_pop.NumDimensions - 1) = state.dp.p_total_pop;
-    output_state.births(i) = state.dp.births(0);
+    output_state.births(i) = state.dp.births;
     output_state.p_total_pop_natural_deaths.chip(i, output_state.p_total_pop_natural_deaths.NumDimensions - 1) = state.dp.p_total_pop_natural_deaths;
     return;
   }
@@ -258,7 +258,7 @@ struct HivSimulationStateSaver {
 public:
   void save_state(HivSimulationOutputState<ModelVariant, real_type> &full_state,
                   const size_t i,
-                  const State<ModelVariant, real_type, true> &state) {}
+                  const State<ModelVariant, real_type> &state) {}
 };
 
 template<typename ModelVariant, typename real_type>
@@ -266,7 +266,7 @@ struct HivSimulationStateSaver<ModelVariant, real_type, std::enable_if_t<ModelVa
 public:
   void save_state(HivSimulationOutputState<ModelVariant, real_type> &output_state,
                   const size_t i,
-                  const State<ModelVariant, real_type, true> &state) {
+                  const State<ModelVariant, real_type> &state) {
     output_state.p_hiv_pop.chip(i, output_state.p_hiv_pop.NumDimensions - 1) = state.hiv.p_hiv_pop;
     output_state.p_hiv_pop_natural_deaths.chip(i, output_state.p_hiv_pop_natural_deaths.NumDimensions - 1) = state.hiv.p_hiv_pop_natural_deaths;
     output_state.h_hiv_adult.chip(i, output_state.h_hiv_adult.NumDimensions - 1) = state.hiv.h_hiv_adult;
@@ -285,7 +285,7 @@ struct ChildModelStateSaver<ChildModel, real_type> {
 public:
   void save_state(ChildModelOutputState<ChildModel, real_type> &output_state,
                   const size_t i,
-                  const State<ChildModel, real_type, true> &state) {
+                  const State<ChildModel, real_type> &state) {
     output_state.hc1_hiv_pop.chip(i, output_state.hc1_hiv_pop.NumDimensions - 1) = state.children.hc1_hiv_pop;
     output_state.hc2_hiv_pop.chip(i, output_state.hc2_hiv_pop.NumDimensions - 1) = state.children.hc2_hiv_pop;
     output_state.hc1_art_pop.chip(i, output_state.hc1_art_pop.NumDimensions - 1) = state.children.hc1_art_pop;
@@ -294,11 +294,11 @@ public:
     output_state.hc2_noart_aids_deaths.chip(i, output_state.hc2_noart_aids_deaths.NumDimensions - 1) = state.children.hc2_noart_aids_deaths;
     output_state.hc1_art_aids_deaths.chip(i, output_state.hc1_art_aids_deaths.NumDimensions - 1) = state.children.hc1_art_aids_deaths;
     output_state.hc2_art_aids_deaths.chip(i, output_state.hc2_art_aids_deaths.NumDimensions - 1) = state.children.hc2_art_aids_deaths;
-    output_state.hiv_births(i) = state.children.hiv_births(0);
+    output_state.hiv_births(i) = state.children.hiv_births;
     output_state.hc_art_init.chip(i, output_state.hc_art_init.NumDimensions - 1) = state.children.hc_art_init;
     output_state.hc_art_need_init.chip(i, output_state.hc_art_need_init.NumDimensions - 1) = state.children.hc_art_need_init;
-    output_state.ctx_need(i) = state.children.ctx_need(0);
-    output_state.ctx_mean(i) = state.children.ctx_mean(0);
+    output_state.ctx_need(i) = state.children.ctx_need;
+    output_state.ctx_mean(i) = state.children.ctx_mean;
     return;
   }
 };

--- a/inst/include/hiv_demographic_projection.hpp
+++ b/inst/include/hiv_demographic_projection.hpp
@@ -8,11 +8,11 @@ namespace leapfrog {
 
 namespace internal {
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_hiv_ageing_and_mortality(int t,
                                   const Parameters<ModelVariant, real_type> &pars,
-                                  const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                  State<ModelVariant, real_type, OwnedData> &state_next,
+                                  const State<ModelVariant, real_type> &state_curr,
+                                  State<ModelVariant, real_type> &state_next,
                                   IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss_d = StateSpace<ModelVariant>().dp;
   const auto& p_dm = pars.dp.demography;
@@ -33,11 +33,11 @@ void run_hiv_ageing_and_mortality(int t,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_age_15_entrants(int t,
                          const Parameters<ModelVariant, real_type> &pars,
-                         const State<ModelVariant, real_type, OwnedData> &state_curr,
-                         State<ModelVariant, real_type, OwnedData> &state_next,
+                         const State<ModelVariant, real_type> &state_curr,
+                         State<ModelVariant, real_type> &state_next,
                          IntermediateData<ModelVariant, real_type> &intermediate) {
   static_assert(ModelVariant::run_child_model,
                 "run_hiv_child_infections can only be called for model variants where run_child_model is true");
@@ -64,11 +64,11 @@ void run_age_15_entrants(int t,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_hiv_and_art_stratified_ageing(int t,
                                        const Parameters<ModelVariant, real_type> &pars,
-                                       const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                       State<ModelVariant, real_type, OwnedData> &state_next,
+                                       const State<ModelVariant, real_type> &state_curr,
+                                       State<ModelVariant, real_type> &state_next,
                                        IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss = StateSpace<ModelVariant>();
   constexpr auto ss_h = ss.hiv;
@@ -143,11 +143,11 @@ void run_hiv_and_art_stratified_ageing(int t,
 }
 
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_hiv_and_art_stratified_deaths_and_migration(int t,
                                                      const Parameters<ModelVariant, real_type> &pars,
-                                                     const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                                     State<ModelVariant, real_type, OwnedData> &state_next,
+                                                     const State<ModelVariant, real_type> &state_curr,
+                                                     State<ModelVariant, real_type> &state_next,
                                                      IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss_h = StateSpace<ModelVariant>().hiv;
   constexpr auto ss_d = StateSpace<ModelVariant>().dp;
@@ -207,11 +207,11 @@ void run_hiv_and_art_stratified_deaths_and_migration(int t,
 
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_hiv_pop_demographic_projection(int t,
                                         const Parameters<ModelVariant, real_type> &pars,
-                                        const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                        State<ModelVariant, real_type, OwnedData> &state_next,
+                                        const State<ModelVariant, real_type> &state_curr,
+                                        State<ModelVariant, real_type> &state_next,
                                         internal::IntermediateData<ModelVariant, real_type> &intermediate) {
 
   internal::run_hiv_ageing_and_mortality<ModelVariant>(t, pars, state_curr, state_next, intermediate);
@@ -227,11 +227,11 @@ void run_hiv_pop_demographic_projection(int t,
 }
 
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_hiv_pop_end_year_migration(int t,
                                     const Parameters<ModelVariant, real_type> &pars,
-                                    const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                    State<ModelVariant, real_type, OwnedData> &state_next,
+                                    const State<ModelVariant, real_type> &state_curr,
+                                    State<ModelVariant, real_type> &state_next,
                                     internal::IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss_h = StateSpace<ModelVariant>().hiv;
   constexpr auto ss_d = StateSpace<ModelVariant>().dp;

--- a/inst/include/leapfrog_py.hpp
+++ b/inst/include/leapfrog_py.hpp
@@ -22,11 +22,11 @@ namespace leapfrog {
  * @param state_next The next state of the model.
  * @return None, updates state_next in place
  */
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void project_single_year(int time_step,
                          const Parameters<ModelVariant, real_type> &pars,
-                         const State<ModelVariant, real_type, OwnedData> &state_curr,
-                         State<ModelVariant, real_type, OwnedData> &state_next) {
+                         const State<ModelVariant, real_type> &state_curr,
+                         State<ModelVariant, real_type> &state_next) {
 
   internal::IntermediateData<ModelVariant, real_type> intermediate(pars.options.hAG_15plus);
   intermediate.reset();

--- a/inst/include/model_simulation.hpp
+++ b/inst/include/model_simulation.hpp
@@ -20,11 +20,11 @@ void distribute_rate_over_sexes(const int t,
   i_ha.rate_sex(FEMALE) = i_ha.rate_sex(MALE) * p_in.relative_risk_sex(t);
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_calculate_incidence_rate(int t,
                                   const Parameters<ModelVariant, real_type> &pars,
-                                  const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                  State<ModelVariant, real_type, OwnedData> &state_next,
+                                  const State<ModelVariant, real_type> &state_curr,
+                                  State<ModelVariant, real_type> &state_next,
                                   IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss_d = StateSpace<ModelVariant>().dp;
   const auto& p_op = pars.options;
@@ -45,12 +45,12 @@ void run_calculate_incidence_rate(int t,
 }
 
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_disease_progression_and_mortality(int hiv_step,
                                            int t,
                                            const Parameters<ModelVariant, real_type> &pars,
-                                           const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                           State<ModelVariant, real_type, OwnedData> &state_next,
+                                           const State<ModelVariant, real_type> &state_curr,
+                                           State<ModelVariant, real_type> &state_next,
                                            IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss_h = StateSpace<ModelVariant>().hiv;
   constexpr auto ss_d = StateSpace<ModelVariant>().dp;
@@ -88,12 +88,12 @@ void run_disease_progression_and_mortality(int hiv_step,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_new_p_infections(int hiv_step,
                           int t,
                           const Parameters<ModelVariant, real_type> &pars,
-                          const State<ModelVariant, real_type, OwnedData> &state_curr,
-                          State<ModelVariant, real_type, OwnedData> &state_next,
+                          const State<ModelVariant, real_type> &state_curr,
+                          State<ModelVariant, real_type> &state_next,
                           IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss = StateSpace<ModelVariant>().dp;
   const auto& p_in = pars.hiv.incidence;
@@ -128,12 +128,12 @@ void run_new_p_infections(int hiv_step,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_new_hiv_p_infections(int hiv_step,
                               int t,
                               const Parameters<ModelVariant, real_type> &pars,
-                              const State<ModelVariant, real_type, OwnedData> &state_curr,
-                              State<ModelVariant, real_type, OwnedData> &state_next,
+                              const State<ModelVariant, real_type> &state_curr,
+                              State<ModelVariant, real_type> &state_next,
                               IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss_h = StateSpace<ModelVariant>().hiv;
   constexpr auto ss_d = StateSpace<ModelVariant>().dp;
@@ -162,12 +162,12 @@ void run_new_hiv_p_infections(int hiv_step,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_art_progression_and_mortality(int hiv_step,
                                        int t,
                                        const Parameters<ModelVariant, real_type> &pars,
-                                       const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                       State<ModelVariant, real_type, OwnedData> &state_next,
+                                       const State<ModelVariant, real_type> &state_curr,
+                                       State<ModelVariant, real_type> &state_next,
                                        IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss_h = StateSpace<ModelVariant>().hiv;
   constexpr auto ss_d = StateSpace<ModelVariant>().dp;
@@ -213,12 +213,12 @@ void run_art_progression_and_mortality(int hiv_step,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_h_art_initiation(int hiv_step,
                           int t,
                           const Parameters<ModelVariant, real_type> &pars,
-                          const State<ModelVariant, real_type, OwnedData> &state_curr,
-                          State<ModelVariant, real_type, OwnedData> &state_next,
+                          const State<ModelVariant, real_type> &state_curr,
+                          State<ModelVariant, real_type> &state_next,
                           IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss_h = StateSpace<ModelVariant>().hiv;
   constexpr auto ss_d = StateSpace<ModelVariant>().dp;
@@ -355,12 +355,12 @@ void run_h_art_initiation(int hiv_step,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_update_art_stratification(int hiv_step,
                                    int t,
                                    const Parameters<ModelVariant, real_type> &pars,
-                                   const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                   State<ModelVariant, real_type, OwnedData> &state_next,
+                                   const State<ModelVariant, real_type> &state_curr,
+                                   State<ModelVariant, real_type> &state_next,
                                    IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss_h = StateSpace<ModelVariant>().hiv;
   constexpr auto ss_d = StateSpace<ModelVariant>().dp;
@@ -379,12 +379,12 @@ void run_update_art_stratification(int hiv_step,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_update_hiv_stratification(int hiv_step,
                                    int t,
                                    const Parameters<ModelVariant, real_type> &pars,
-                                   const State<ModelVariant, real_type, OwnedData> &state_curr,
-                                   State<ModelVariant, real_type, OwnedData> &state_next,
+                                   const State<ModelVariant, real_type> &state_curr,
+                                   State<ModelVariant, real_type> &state_next,
                                    IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss_h = StateSpace<ModelVariant>().hiv;
   constexpr auto ss_d = StateSpace<ModelVariant>().dp;
@@ -401,12 +401,12 @@ void run_update_hiv_stratification(int hiv_step,
   }
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_remove_p_hiv_deaths(int hiv_step,
                              int t,
                              const Parameters<ModelVariant, real_type> &pars,
-                             const State<ModelVariant, real_type, OwnedData> &state_curr,
-                             State<ModelVariant, real_type, OwnedData> &state_next,
+                             const State<ModelVariant, real_type> &state_curr,
+                             State<ModelVariant, real_type> &state_next,
                              IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss_h = StateSpace<ModelVariant>().hiv;
   constexpr auto ss_d = StateSpace<ModelVariant>().dp;
@@ -445,11 +445,11 @@ void run_remove_p_hiv_deaths(int hiv_step,
 
 }
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void run_hiv_model_simulation(int t,
                               const Parameters<ModelVariant, real_type> &pars,
-                              const State<ModelVariant, real_type, OwnedData> &state_curr,
-                              State<ModelVariant, real_type, OwnedData> &state_next,
+                              const State<ModelVariant, real_type> &state_curr,
+                              State<ModelVariant, real_type> &state_next,
                               internal::IntermediateData<ModelVariant, real_type> &intermediate) {
   constexpr auto ss = StateSpace<ModelVariant>().hiv;
   const auto& p_tx = pars.hiv.art;

--- a/inst/include/project_year.hpp
+++ b/inst/include/project_year.hpp
@@ -11,11 +11,11 @@ namespace leapfrog {
 
 namespace internal {
 
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void project_year(int t,
                   const Parameters<ModelVariant, real_type> &pars,
-                  const State<ModelVariant, real_type, OwnedData> &state_curr,
-                  State<ModelVariant, real_type, OwnedData> &state_next,
+                  const State<ModelVariant, real_type> &state_curr,
+                  State<ModelVariant, real_type> &state_next,
                   IntermediateData<ModelVariant, real_type> &intermediate) {
   run_general_pop_demographic_projection<ModelVariant>(t, pars, state_curr, state_next,
                                                        intermediate);

--- a/inst/include/state_saver.hpp
+++ b/inst/include/state_saver.hpp
@@ -45,7 +45,7 @@ public:
   }
 
 
-  void save_state(const State<ModelVariant, real_type, true> &state, int current_year) {
+  void save_state(const State<ModelVariant, real_type> &state, int current_year) {
     for (size_t i = 0; i < save_steps.size(); ++i) {
       if (current_year == save_steps[i]) {
         dp.save_state(full_state.dp, i, state);

--- a/inst/standalone_model/simulate_model.cpp
+++ b/inst/standalone_model/simulate_model.cpp
@@ -263,7 +263,7 @@ int main(int argc, char *argv[]) {
 
   std::vector<int> save_steps(sim_years);
   std::iota(save_steps.begin(), save_steps.end(), 0);
-  leapfrog::StateSaver<leapfrog::BaseModelFullAgeStratification, double> state_output(
+  leapfrog::StateSaver<leapfrog::HivFullAgeStratification, double> state_output(
       sim_years, save_steps);
 
   const char *n_runs_char = std::getenv("N_RUNS");
@@ -279,17 +279,17 @@ int main(int argc, char *argv[]) {
   }
 
   for (size_t i = 0; i < n_runs; ++i) {
-    auto state_current = leapfrog::State<leapfrog::HivFullAgeStratification, double, true>(
+    auto state_current = leapfrog::State<leapfrog::HivFullAgeStratification, double>(
         params);
     auto state_next = state_current;
-    leapfrog::set_initial_state<leapfrog::HivFullAgeStratification, double, true>(state_current, params);
+    leapfrog::set_initial_state<leapfrog::HivFullAgeStratification, double>(state_current, params);
 
     // Save initial state
     state_output.save_state(state_current, 0);
 
     // Each time step is mid-point of the year
     for (int step = 1; step < sim_years; ++step) {
-      leapfrog::internal::project_year<leapfrog::HivFullAgeStratification, double, true>(step, params, state_current, state_next, intermediate);
+      leapfrog::internal::project_year<leapfrog::HivFullAgeStratification, double>(step, params, state_current, state_next, intermediate);
       state_output.save_state(state_next, step);
       std::swap(state_current, state_next);
       intermediate.reset();

--- a/leapfrog-py/README.md
+++ b/leapfrog-py/README.md
@@ -75,6 +75,8 @@ cmake --build . --target install
 * Run lint auto-format `uvx ruff check --fix` or `uvx black .`
 * Run lint typing `uv run --group check mypy --install-types --non-interactive src tests`
 
+uv will rebuild automatically if you make a change to the C++ code in the `src` directory, but you will need to force it to reinstall if you updated the C++ library. To force recompilation, pass `--reinstall-package leapfrog-py`. If you want to see verbose output pass `--verbose`. These can be passed and used with any command.
+
 To build with pipx
 
 ```console

--- a/leapfrog-py/src/leapfrog/interface.cpp
+++ b/leapfrog-py/src/leapfrog/interface.cpp
@@ -10,6 +10,7 @@ namespace py = pybind11;
 
 namespace {
 using Eigen::Sizes;
+using Eigen::TensorFixedSize;
 }
 
 PYBIND11_MODULE(leapfrog, m) {
@@ -202,27 +203,27 @@ PYBIND11_MODULE(leapfrog, m) {
         .def_readonly("hiv", &leapfrog::Parameters<leapfrog::ChildModel, double>::hiv)
         .def_readonly("children", &leapfrog::Parameters<leapfrog::ChildModel, double>::children);
 
-    py::class_<leapfrog::DemographicProjectionState<leapfrog::ChildModel, double, false>>(m, "DemographicProjectionState")
-        .def(py::init<const leapfrog::TensorType<double, Sizes<leapfrog::pAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<1>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::pAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&>(),
+    py::class_<leapfrog::DemographicProjectionState<leapfrog::ChildModel, double>>(m, "DemographicProjectionState")
+        .def(py::init<const TensorFixedSize<double, Sizes<leapfrog::pAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      double,
+                      const TensorFixedSize<double, Sizes<leapfrog::pAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&>(),
                       py::arg("p_total_pop"),
                       py::arg("births"),
                       py::arg("p_total_pop_natural_deaths"))
-        .def_readonly("p_total_pop", &leapfrog::DemographicProjectionState<leapfrog::ChildModel, double, false>::p_total_pop)
-        .def_readonly("births", &leapfrog::DemographicProjectionState<leapfrog::ChildModel, double, false>::births)
-        .def_readonly("p_total_pop_natural_deaths", &leapfrog::DemographicProjectionState<leapfrog::ChildModel, double, false>::p_total_pop_natural_deaths);
+        .def_readonly("p_total_pop", &leapfrog::DemographicProjectionState<leapfrog::ChildModel, double>::p_total_pop)
+        .def_readonly("births", &leapfrog::DemographicProjectionState<leapfrog::ChildModel, double>::births)
+        .def_readonly("p_total_pop_natural_deaths", &leapfrog::DemographicProjectionState<leapfrog::ChildModel, double>::p_total_pop_natural_deaths);
 
-    py::class_<leapfrog::HivSimulationState<leapfrog::ChildModel, double, false>>(m, "HivSimulationState")
-        .def(py::init<const leapfrog::TensorType<double, Sizes<leapfrog::pAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::pAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::hDS<leapfrog::ChildModel>, leapfrog::hAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::hTS<leapfrog::ChildModel>, leapfrog::hDS<leapfrog::ChildModel>, leapfrog::hAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::hDS<leapfrog::ChildModel>, leapfrog::hAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::pAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::hTS<leapfrog::ChildModel>, leapfrog::hDS<leapfrog::ChildModel>, leapfrog::hAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::hDS<leapfrog::ChildModel>, leapfrog::hAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::pAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&>(),
+    py::class_<leapfrog::HivSimulationState<leapfrog::ChildModel, double>>(m, "HivSimulationState")
+        .def(py::init<const TensorFixedSize<double, Sizes<leapfrog::pAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      const TensorFixedSize<double, Sizes<leapfrog::pAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      const TensorFixedSize<double, Sizes<leapfrog::hDS<leapfrog::ChildModel>, leapfrog::hAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      const TensorFixedSize<double, Sizes<leapfrog::hTS<leapfrog::ChildModel>, leapfrog::hDS<leapfrog::ChildModel>, leapfrog::hAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      const TensorFixedSize<double, Sizes<leapfrog::hDS<leapfrog::ChildModel>, leapfrog::hAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      const TensorFixedSize<double, Sizes<leapfrog::pAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      const TensorFixedSize<double, Sizes<leapfrog::hTS<leapfrog::ChildModel>, leapfrog::hDS<leapfrog::ChildModel>, leapfrog::hAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      const TensorFixedSize<double, Sizes<leapfrog::hDS<leapfrog::ChildModel>, leapfrog::hAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      const TensorFixedSize<double, Sizes<leapfrog::pAG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&>(),
                       py::arg("p_hiv_pop"),
                       py::arg("p_hiv_pop_natural_deaths"),
                       py::arg("h_hiv_adult"),
@@ -232,30 +233,31 @@ PYBIND11_MODULE(leapfrog, m) {
                       py::arg("h_hiv_deaths_art"),
                       py::arg("h_art_initiation"),
                       py::arg("p_hiv_deaths"))
-        .def_readonly("p_hiv_pop", &leapfrog::HivSimulationState<leapfrog::ChildModel, double, false>::p_hiv_pop)
-        .def_readonly("p_hiv_pop_natural_deaths", &leapfrog::HivSimulationState<leapfrog::ChildModel, double, false>::p_hiv_pop_natural_deaths)
-        .def_readonly("h_hiv_adult", &leapfrog::HivSimulationState<leapfrog::ChildModel, double, false>::h_hiv_adult)
-        .def_readonly("h_art_adult", &leapfrog::HivSimulationState<leapfrog::ChildModel, double, false>::h_art_adult)
-        .def_readonly("h_hiv_deaths_no_art", &leapfrog::HivSimulationState<leapfrog::ChildModel, double, false>::h_hiv_deaths_no_art)
-        .def_readonly("p_infections", &leapfrog::HivSimulationState<leapfrog::ChildModel, double, false>::p_infections)
-        .def_readonly("h_hiv_deaths_art", &leapfrog::HivSimulationState<leapfrog::ChildModel, double, false>::h_hiv_deaths_art)
-        .def_readonly("h_art_initiation", &leapfrog::HivSimulationState<leapfrog::ChildModel, double, false>::h_art_initiation)
-        .def_readonly("p_hiv_deaths", &leapfrog::HivSimulationState<leapfrog::ChildModel, double, false>::p_hiv_deaths);
+        .def_readonly("p_hiv_pop", &leapfrog::HivSimulationState<leapfrog::ChildModel, double>::p_hiv_pop)
+        .def_readonly("p_hiv_pop_natural_deaths", &leapfrog::HivSimulationState<leapfrog::ChildModel, double>::p_hiv_pop_natural_deaths)
+        .def_readonly("h_hiv_adult", &leapfrog::HivSimulationState<leapfrog::ChildModel, double>::h_hiv_adult)
+        .def_readonly("h_art_adult", &leapfrog::HivSimulationState<leapfrog::ChildModel, double>::h_art_adult)
+        .def_readonly("h_hiv_deaths_no_art", &leapfrog::HivSimulationState<leapfrog::ChildModel, double>::h_hiv_deaths_no_art)
+        .def_readonly("p_infections", &leapfrog::HivSimulationState<leapfrog::ChildModel, double>::p_infections)
+        .def_readonly("h_hiv_deaths_art", &leapfrog::HivSimulationState<leapfrog::ChildModel, double>::h_hiv_deaths_art)
+        .def_readonly("h_art_initiation", &leapfrog::HivSimulationState<leapfrog::ChildModel, double>::h_art_initiation)
+        .def_readonly("p_hiv_deaths", &leapfrog::HivSimulationState<leapfrog::ChildModel, double>::p_hiv_deaths);
 
-    py::class_<leapfrog::ChildModelState<leapfrog::ChildModel, double, false>>(m, "ChildModelState")
-        .def(py::init<const leapfrog::TensorType<double, Sizes<leapfrog::hc1DS<leapfrog::ChildModel>, leapfrog::hcTT<leapfrog::ChildModel>, leapfrog::hc1AG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::hc2DS<leapfrog::ChildModel>, leapfrog::hcTT<leapfrog::ChildModel>, leapfrog::hc2AG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::hTS<leapfrog::ChildModel>, leapfrog::hc1DS<leapfrog::ChildModel>, leapfrog::hc1AG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::hTS<leapfrog::ChildModel>, leapfrog::hc2DS<leapfrog::ChildModel>, leapfrog::hc2AG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::hc1DS<leapfrog::ChildModel>, leapfrog::hcTT<leapfrog::ChildModel>, leapfrog::hc1AG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::hc2DS<leapfrog::ChildModel>, leapfrog::hcTT<leapfrog::ChildModel>, leapfrog::hc2AG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::hTS<leapfrog::ChildModel>, leapfrog::hc1DS<leapfrog::ChildModel>, leapfrog::hc1AG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::hTS<leapfrog::ChildModel>, leapfrog::hc2DS<leapfrog::ChildModel>, leapfrog::hc2AG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<1>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::hcAG_coarse<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<leapfrog::hc1DS<leapfrog::ChildModel>, leapfrog::hcTT<leapfrog::ChildModel>, leapfrog::hcAG_end<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>, false>&,
-                      const leapfrog::TensorType<double, Sizes<1>, false>&,
-                      const leapfrog::TensorType<double, Sizes<1>, false>&>(),
+
+        py::class_<leapfrog::ChildModelState<leapfrog::ChildModel, double>>(m, "ChildModelState")
+        .def(py::init<const TensorFixedSize<double, Sizes<leapfrog::hc1DS<leapfrog::ChildModel>, leapfrog::hcTT<leapfrog::ChildModel>, leapfrog::hc1AG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      const TensorFixedSize<double, Sizes<leapfrog::hc2DS<leapfrog::ChildModel>, leapfrog::hcTT<leapfrog::ChildModel>, leapfrog::hc2AG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      const TensorFixedSize<double, Sizes<leapfrog::hTS<leapfrog::ChildModel>, leapfrog::hc1DS<leapfrog::ChildModel>, leapfrog::hc1AG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      const TensorFixedSize<double, Sizes<leapfrog::hTS<leapfrog::ChildModel>, leapfrog::hc2DS<leapfrog::ChildModel>, leapfrog::hc2AG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      const TensorFixedSize<double, Sizes<leapfrog::hc1DS<leapfrog::ChildModel>, leapfrog::hcTT<leapfrog::ChildModel>, leapfrog::hc1AG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      const TensorFixedSize<double, Sizes<leapfrog::hc2DS<leapfrog::ChildModel>, leapfrog::hcTT<leapfrog::ChildModel>, leapfrog::hc2AG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      const TensorFixedSize<double, Sizes<leapfrog::hTS<leapfrog::ChildModel>, leapfrog::hc1DS<leapfrog::ChildModel>, leapfrog::hc1AG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      const TensorFixedSize<double, Sizes<leapfrog::hTS<leapfrog::ChildModel>, leapfrog::hc2DS<leapfrog::ChildModel>, leapfrog::hc2AG<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      double,
+                      const TensorFixedSize<double, Sizes<leapfrog::hcAG_coarse<leapfrog::ChildModel>>>&,
+                      const TensorFixedSize<double, Sizes<leapfrog::hc1DS<leapfrog::ChildModel>, leapfrog::hcTT<leapfrog::ChildModel>, leapfrog::hcAG_end<leapfrog::ChildModel>, leapfrog::NS<leapfrog::ChildModel>>>&,
+                      double,
+                      double>(),
                       py::arg("hc1_hiv_pop"),
                       py::arg("hc2_hiv_pop"),
                       py::arg("hc1_art_pop"),
@@ -269,31 +271,31 @@ PYBIND11_MODULE(leapfrog, m) {
                       py::arg("hc_art_need_init"),
                       py::arg("ctx_need"),
                       py::arg("ctx_mean"))
-        .def_readonly("hc1_hiv_pop", &leapfrog::ChildModelState<leapfrog::ChildModel, double, false>::hc1_hiv_pop)
-        .def_readonly("hc2_hiv_pop", &leapfrog::ChildModelState<leapfrog::ChildModel, double, false>::hc2_hiv_pop)
-        .def_readonly("hc1_art_pop", &leapfrog::ChildModelState<leapfrog::ChildModel, double, false>::hc1_art_pop)
-        .def_readonly("hc2_art_pop", &leapfrog::ChildModelState<leapfrog::ChildModel, double, false>::hc2_art_pop)
-        .def_readonly("hc1_noart_aids_deaths", &leapfrog::ChildModelState<leapfrog::ChildModel, double, false>::hc1_noart_aids_deaths)
-        .def_readonly("hc2_noart_aids_deaths", &leapfrog::ChildModelState<leapfrog::ChildModel, double, false>::hc2_noart_aids_deaths)
-        .def_readonly("hc1_art_aids_deaths", &leapfrog::ChildModelState<leapfrog::ChildModel, double, false>::hc1_art_aids_deaths)
-        .def_readonly("hc2_art_aids_deaths", &leapfrog::ChildModelState<leapfrog::ChildModel, double, false>::hc2_art_aids_deaths)
-        .def_readonly("hiv_births", &leapfrog::ChildModelState<leapfrog::ChildModel, double, false>::hiv_births)
-        .def_readonly("hc_art_init", &leapfrog::ChildModelState<leapfrog::ChildModel, double, false>::hc_art_init)
-        .def_readonly("hc_art_need_init", &leapfrog::ChildModelState<leapfrog::ChildModel, double, false>::hc_art_need_init)
-        .def_readonly("ctx_need", &leapfrog::ChildModelState<leapfrog::ChildModel, double, false>::ctx_need)
-        .def_readonly("ctx_mean", &leapfrog::ChildModelState<leapfrog::ChildModel, double, false>::ctx_mean);
+        .def_readonly("hc1_hiv_pop", &leapfrog::ChildModelState<leapfrog::ChildModel, double>::hc1_hiv_pop)
+        .def_readonly("hc2_hiv_pop", &leapfrog::ChildModelState<leapfrog::ChildModel, double>::hc2_hiv_pop)
+        .def_readonly("hc1_art_pop", &leapfrog::ChildModelState<leapfrog::ChildModel, double>::hc1_art_pop)
+        .def_readonly("hc2_art_pop", &leapfrog::ChildModelState<leapfrog::ChildModel, double>::hc2_art_pop)
+        .def_readonly("hc1_noart_aids_deaths", &leapfrog::ChildModelState<leapfrog::ChildModel, double>::hc1_noart_aids_deaths)
+        .def_readonly("hc2_noart_aids_deaths", &leapfrog::ChildModelState<leapfrog::ChildModel, double>::hc2_noart_aids_deaths)
+        .def_readonly("hc1_art_aids_deaths", &leapfrog::ChildModelState<leapfrog::ChildModel, double>::hc1_art_aids_deaths)
+        .def_readonly("hc2_art_aids_deaths", &leapfrog::ChildModelState<leapfrog::ChildModel, double>::hc2_art_aids_deaths)
+        .def_readonly("hiv_births", &leapfrog::ChildModelState<leapfrog::ChildModel, double>::hiv_births)
+        .def_readonly("hc_art_init", &leapfrog::ChildModelState<leapfrog::ChildModel, double>::hc_art_init)
+        .def_readonly("hc_art_need_init", &leapfrog::ChildModelState<leapfrog::ChildModel, double>::hc_art_need_init)
+        .def_readonly("ctx_need", &leapfrog::ChildModelState<leapfrog::ChildModel, double>::ctx_need)
+        .def_readonly("ctx_mean", &leapfrog::ChildModelState<leapfrog::ChildModel, double>::ctx_mean);
 
-    py::class_<leapfrog::State<leapfrog::ChildModel, double, false>>(m, "State")
-        .def(py::init<const leapfrog::DemographicProjectionState<leapfrog::ChildModel, double, false>&,
-                      const leapfrog::HivSimulationState<leapfrog::ChildModel, double, false>&,
-                      const leapfrog::ChildModelState<leapfrog::ChildModel, double, false>&>())
-        .def_readonly("dp", &leapfrog::State<leapfrog::ChildModel, double, false>::dp)
-        .def_readonly("hiv", &leapfrog::State<leapfrog::ChildModel, double, false>::hiv)
-        .def_readonly("children", &leapfrog::State<leapfrog::ChildModel, double, false>::children);
+    py::class_<leapfrog::State<leapfrog::ChildModel, double>>(m, "State")
+        .def(py::init<const leapfrog::DemographicProjectionState<leapfrog::ChildModel, double>&,
+                      const leapfrog::HivSimulationState<leapfrog::ChildModel, double>&,
+                      const leapfrog::ChildModelState<leapfrog::ChildModel, double>&>())
+        .def_readonly("dp", &leapfrog::State<leapfrog::ChildModel, double>::dp)
+        .def_readonly("hiv", &leapfrog::State<leapfrog::ChildModel, double>::hiv)
+        .def_readonly("children", &leapfrog::State<leapfrog::ChildModel, double>::children);
 
     m.def(
         "project_single_year_cpp",
-        &leapfrog::project_single_year<leapfrog::ChildModel, double, false>,
+        &leapfrog::project_single_year<leapfrog::ChildModel, double>,
         py::arg("time_step"),
         py::arg("pars"),
         py::arg("state_curr"),
@@ -303,7 +305,7 @@ PYBIND11_MODULE(leapfrog, m) {
 
     m.def(
         "set_initial_state_cpp",
-        &leapfrog::set_initial_state<leapfrog::ChildModel, double, false>,
+        &leapfrog::set_initial_state<leapfrog::ChildModel, double>,
         py::arg("state"),
         py::arg("pars"),
         "Set initial state from the parameters"

--- a/vignettes/development.Rmd
+++ b/vignettes/development.Rmd
@@ -31,11 +31,11 @@ All model functions are templated on the model variant, and any conditional beha
 All model functions should have the same signature e.g.
 
 ```
-template<typename ModelVariant, typename real_type, bool OwnedData>
+template<typename ModelVariant, typename real_type>
 void my_model_function(int time_step,
                        const Parameters<ModelVariant, real_type> &pars,
-                       const State<ModelVariant, real_type, OwnedData> &state_curr,
-                       State<ModelVariant, real_type, OwnedData> &state_next,
+                       const State<ModelVariant, real_type> &state_curr,
+                       State<ModelVariant, real_type> &state_next,
                        IntermediateData<ModelVariant, real_type> &intermediate) {
 ```
 
@@ -114,7 +114,7 @@ Note that the dims can be any of the state space sizes or `proj_years` for the n
 
 ### Intermediate data
 
-Intermediate data is used as a place to store 
+Intermediate data is used as a place to store
 The intermediate data is not handled by code generation as it only requires changes in one place. You can make modifications by adding new data into the struct in [`inst/include/types.hpp`](https://github.com/mrc-ide/frogger/blob/main/inst/include/types.hpp), making sure to set its default value in the `reset` function on the struct.
 
 ## Adding a new model variant


### PR DESCRIPTION
The flag adds a fair bit of complexity, and we're not sure we'll even need it. Indeed we're going to have to copy from C ordered data in Python to Fortran ordered anyway, so we're going to have to copy on the way in and the way out.

This backs it out for now, we can always add it back in if we think we need it.

So I realise in doing this we still need the 2 constructors. 1 from R where we always construct state with 0s. And one from Python. In Python when we want to run year-by-year we want to be passing in the state data. As we need last time step data to have actual values, and indeed if there is some other Avenir module which has run before us (though I don't think this is the case) then we have to use those values.

So actually does beg a question of how we want to handle this, it would be nice to have 1 copy.

At the moment what this is doing is for the State
1. Initialising a big (Fortran ordered) numpy array for each state of 0s
2. Copying a slice of this at time `t` and a slice at time `t - 1` into a `State` object of Eigen::TensorFixedSize on the call to `_initialise_state`. I believe this data is owned by C++ but we should double check it, it will depend on what pybind11 is doing under the hood. (this is the bit of docs I was thinking about when we chatted but I think is only about returning https://pybind11.readthedocs.io/en/stable/advanced/functions.html#return-value-policies)
3. Running for a single time step
4. Copying the data out from the Eigen::TensorFixedSize back into the big numpy array

We should probably chat to Rob G and work out the desired data flow here