### PR TITLE
rename run_update_hiv/art_stratification to run_update_*_adult()

### DIFF
--- a/r-package/inst/include/models/adult_hiv_model_simulation.hpp
+++ b/r-package/inst/include/models/adult_hiv_model_simulation.hpp
@@ -78,10 +78,10 @@ struct AdultHivModelSimulation<Config> {
       if (t >= opts.ts_art_start) {
         run_art_progression_and_mortality(hiv_step);
         run_h_art_initiation(hiv_step);
-        run_update_art_stratification(hiv_step);
+        run_update_art_adult(hiv_step);
       }
 
-      run_update_hiv_stratification(hiv_step);
+      run_update_hiv_adult(hiv_step);
       run_remove_p_hiv_deaths(hiv_step);
     }
   };
@@ -389,7 +389,7 @@ struct AdultHivModelSimulation<Config> {
     }
   };
 
-  void run_update_art_stratification(int hiv_step) {
+  void run_update_art_adult(int hiv_step) {
     auto& n_ha = state_next.ha;
     auto& i_ha = intermediate.ha;
 
@@ -404,7 +404,7 @@ struct AdultHivModelSimulation<Config> {
     }
   };
 
-  void run_update_hiv_stratification(int hiv_step) {
+  void run_update_hiv_adult(int hiv_step) {
     auto& n_ha = state_next.ha;
     auto& i_ha = intermediate.ha;
 


### PR DESCRIPTION
Small updates for code readability.

`run_update_hiv_stratification()` and `run_update_art_stratification()` evoke to me that that the stratification is being updated. Suggest just naming it consistent with the state space object being updated for clarity.