### PR TITLE
Add new model variant for inputting transmission rate

### DIFF
--- a/cpp_generation/modelSchemas/ModelVariants.json
+++ b/cpp_generation/modelSchemas/ModelVariants.json
@@ -4,41 +4,55 @@
     "run_hiv_simulation": "false",
     "use_coarse_stratification": "false",
     "run_child_model": "false",
-    "run_spectrum_model": "false"
+    "run_spectrum_model": "false",
+    "input_transmission_rate": "false"
   },
   "HivFullAgeStratification": {
     "run_demographic_projection": "true",
     "run_hiv_simulation": "true",
     "use_coarse_stratification": "false",
     "run_child_model": "false",
-    "run_spectrum_model": "false"
+    "run_spectrum_model": "false",
+    "input_transmission_rate": "false"
   },
   "HivCoarseAgeStratification": {
     "run_demographic_projection": "true",
     "run_hiv_simulation": "true",
     "use_coarse_stratification": "true",
     "run_child_model": "false",
-    "run_spectrum_model": "false"
+    "run_spectrum_model": "false",
+    "input_transmission_rate": "false"
   },
   "ChildModel": {
     "run_demographic_projection": "true",
     "run_hiv_simulation": "true",
     "use_coarse_stratification": "false",
     "run_child_model": "true",
-    "run_spectrum_model": "false"
+    "run_spectrum_model": "false",
+    "input_transmission_rate": "false"
   },
   "CoarseChildModel": {
     "run_demographic_projection": "true",
     "run_hiv_simulation": "true",
     "use_coarse_stratification": "true",
     "run_child_model": "true",
-    "run_spectrum_model": "false"
+    "run_spectrum_model": "false",
+    "input_transmission_rate": "false"
   },
   "Spectrum": {
     "run_demographic_projection": "true",
     "run_hiv_simulation": "true",
     "use_coarse_stratification": "false",
     "run_child_model": "true",
-    "run_spectrum_model": "true"
+    "run_spectrum_model": "true",
+    "input_transmission_rate": "false"
+  },
+  "HivCoarseAgeFit": {
+    "run_demographic_projection": "true",
+    "run_hiv_simulation": "true",
+    "use_coarse_stratification": "true",
+    "run_child_model": "false",
+    "run_spectrum_model": "false",
+    "input_transmission_rate": "true"
   }
 }

--- a/cpp_generation/modelSchemas/configs/FtConfig.json
+++ b/cpp_generation/modelSchemas/configs/FtConfig.json
@@ -1,0 +1,17 @@
+{
+  "name": "Ft",
+  "long_name": "Fit",
+  "namespace": "ft",
+  "enable_if": "input_transmission_rate",
+  "state_space": {
+    "default": {}
+  },
+  "pars": {
+    "rvec": {
+      "num_type": "real_type",
+      "dims": ["opts.proj_steps * opts.hts_per_year"]
+    }
+  },
+  "intermediate": {},
+  "state": {}
+}

--- a/cpp_generation/modelSchemas/configs/HaConfig.json
+++ b/cpp_generation/modelSchemas/configs/HaConfig.json
@@ -180,7 +180,7 @@
     "h_deaths_excess_nonaids_agesex": {
       "num_type": "real_type",
       "dims": ["SS::hAG", "SS::NS"]
-    },      
+    },
     "grad": {
       "num_type": "real_type",
       "dims": ["SS::hDS", "SS::hAG", "SS::NS"]
@@ -292,7 +292,7 @@
     "h_deaths_excess_nonaids_no_art": {
       "num_type": "real_type",
       "dims": ["SS::hDS", "SS::hAG", "SS::NS"]
-    },      
+    },
     "p_infections": {
       "num_type": "real_type",
       "dims": ["SS::pAG", "SS::NS"]
@@ -304,7 +304,7 @@
     "h_deaths_excess_nonaids_on_art": {
       "num_type": "real_type",
       "dims": ["SS::hTS", "SS::hDS", "SS::hAG", "SS::NS"]
-    },      
+    },
     "h_art_initiation": {
       "num_type": "real_type",
       "dims": ["SS::hDS", "SS::hAG", "SS::NS"]
@@ -316,7 +316,7 @@
     "p_deaths_excess_nonaids": {
       "num_type": "real_type",
       "dims": ["SS::pAG", "SS::NS"]
-    },      
+    },
     "p_net_migration_hivpop": {
       "num_type": "real_type",
       "dims": ["SS::pAG", "SS::NS"]

--- a/r-package/inst/include/generated/concepts.hpp
+++ b/r-package/inst/include/generated/concepts.hpp
@@ -15,6 +15,7 @@ concept MV = requires (ModelVariant mv) {
   { mv.use_coarse_stratification } -> std::convertible_to<bool>;
   { mv.run_child_model } -> std::convertible_to<bool>;
   { mv.run_spectrum_model } -> std::convertible_to<bool>;
+  { mv.input_transmission_rate } -> std::convertible_to<bool>;
 };
 
 
@@ -32,6 +33,9 @@ concept RunChildModel = MV<typename Config::ModelVariant> && Config::ModelVarian
 
 template<typename Config>
 concept RunSpectrumModel = MV<typename Config::ModelVariant> && Config::ModelVariant::run_spectrum_model;
+
+template<typename Config>
+concept InputTransmissionRate = MV<typename Config::ModelVariant> && Config::ModelVariant::input_transmission_rate;
 
 } // namespace internal
 } // namespace leapfrog

--- a/r-package/inst/include/generated/model_variants.hpp
+++ b/r-package/inst/include/generated/model_variants.hpp
@@ -13,6 +13,7 @@ struct DemographicProjection {
   static constexpr bool use_coarse_stratification = false;
   static constexpr bool run_child_model = false;
   static constexpr bool run_spectrum_model = false;
+  static constexpr bool input_transmission_rate = false;
 };
 struct HivFullAgeStratification {
   static constexpr bool run_demographic_projection = true;
@@ -20,6 +21,7 @@ struct HivFullAgeStratification {
   static constexpr bool use_coarse_stratification = false;
   static constexpr bool run_child_model = false;
   static constexpr bool run_spectrum_model = false;
+  static constexpr bool input_transmission_rate = false;
 };
 struct HivCoarseAgeStratification {
   static constexpr bool run_demographic_projection = true;
@@ -27,6 +29,7 @@ struct HivCoarseAgeStratification {
   static constexpr bool use_coarse_stratification = true;
   static constexpr bool run_child_model = false;
   static constexpr bool run_spectrum_model = false;
+  static constexpr bool input_transmission_rate = false;
 };
 struct ChildModel {
   static constexpr bool run_demographic_projection = true;
@@ -34,6 +37,7 @@ struct ChildModel {
   static constexpr bool use_coarse_stratification = false;
   static constexpr bool run_child_model = true;
   static constexpr bool run_spectrum_model = false;
+  static constexpr bool input_transmission_rate = false;
 };
 struct CoarseChildModel {
   static constexpr bool run_demographic_projection = true;
@@ -41,6 +45,7 @@ struct CoarseChildModel {
   static constexpr bool use_coarse_stratification = true;
   static constexpr bool run_child_model = true;
   static constexpr bool run_spectrum_model = false;
+  static constexpr bool input_transmission_rate = false;
 };
 struct Spectrum {
   static constexpr bool run_demographic_projection = true;
@@ -48,6 +53,15 @@ struct Spectrum {
   static constexpr bool use_coarse_stratification = false;
   static constexpr bool run_child_model = true;
   static constexpr bool run_spectrum_model = true;
+  static constexpr bool input_transmission_rate = false;
+};
+struct HivCoarseAgeFit {
+  static constexpr bool run_demographic_projection = true;
+  static constexpr bool run_hiv_simulation = true;
+  static constexpr bool use_coarse_stratification = true;
+  static constexpr bool run_child_model = false;
+  static constexpr bool run_spectrum_model = false;
+  static constexpr bool input_transmission_rate = true;
 };
 
 }

--- a/r-package/inst/include/models/adult_hiv_model_simulation.hpp
+++ b/r-package/inst/include/models/adult_hiv_model_simulation.hpp
@@ -73,6 +73,9 @@ struct AdultHivModelSimulation<Config> {
       nda::fill(i_ha.h_hiv_deaths_age_sex, 0.0);
       nda::fill(i_ha.h_deaths_excess_nonaids_agesex, 0.0);
       run_disease_progression_and_mortality(hiv_step);
+      if constexpr (ModelVariant::input_transmission_rate) {
+        calc_infections_from_transmission(hiv_step);
+      }
       run_new_p_infections(hiv_step);
       run_new_hiv_p_infections(hiv_step);
 
@@ -156,6 +159,11 @@ struct AdultHivModelSimulation<Config> {
       }
     }
   };
+
+  void calc_infections_from_transmission(int hiv_step) {
+    int ts = (t-1) * opts.hts_per_year + hiv_step;
+    // use rvec(ts) here
+  }
 
   void run_new_p_infections(int hiv_step) {
     const auto& p_ha = pars.ha;

--- a/r-package/src/frogger.cpp
+++ b/r-package/src/frogger.cpp
@@ -19,7 +19,8 @@ std::vector<std::string> list_model_configurations() {
     "HivCoarseAgeStratification",
     "ChildModel",
     "CoarseChildModel",
-    "Spectrum"
+    "Spectrum",
+    "HivCoarseAgeFit"
   };
 }
 
@@ -143,6 +144,8 @@ auto sim_model(const std::string configuration, Args&&... args) {
     return simulate_model<leapfrog::CoarseChildModel>(std::forward<Args>(args)...);
   } else if (configuration == "Spectrum") {
     return simulate_model<leapfrog::Spectrum>(std::forward<Args>(args)...);
+  } else if (configuration == "HivCoarseAgeFit") {
+    return simulate_model<leapfrog::HivCoarseAgeFit>(std::forward<Args>(args)...);
   } else {
     const auto available_variants = list_model_configurations();
     std::ostringstream oss;

--- a/r-package/tests/testthat/test-transmission-input.R
+++ b/r-package/tests/testthat/test-transmission-input.R
@@ -1,0 +1,10 @@
+test_that("initial state set up works as expected", {
+  parameters <- read_parameters(test_path("testdata/adult_parms_coarse.h5"))
+
+  parameters$rvec <- rep(0.1, parameters$hts_per_year * 61)
+
+  out <- run_model(parameters, "HivCoarseAgeFit")
+
+  # Just a smoke test for now, need to flesh it out
+  expect_true(any(out$p_totpop != 0.0))
+})


### PR DESCRIPTION
I started looking at implementing the code for this and got confused quite quickly. I think @jeffeaton if you have capacity to translate the code over from EPPASM that would be much appreciated.

This adds the transmission rate input as a model variant, but possibly we could do this as a runtime parameter. I'm not sure at the moment what the best approach is. But if we get the code in place, we can then always move it from a variant into a runtime switch if we want to.