### PR TITLE
child model: patch hard-coded ages and run-time loop bounds

### DIFF
--- a/leapfrog-core/include/models/adult_hiv_model_simulation.hpp
+++ b/leapfrog-core/include/models/adult_hiv_model_simulation.hpp
@@ -41,6 +41,8 @@ struct AdultHivModelSimulation<Config> {
   static constexpr int hIDX_15PLUS = SS::hIDX_15PLUS;
   static constexpr int hAG_fertility = SS::hAG_fertility;
   static constexpr int p_idx_fertility_first = SS::p_idx_fertility_first;
+  static constexpr int p_fertility_age_groups = SS::p_fertility_age_groups;
+  
 
   // function args
   int t;
@@ -287,19 +289,19 @@ struct AdultHivModelSimulation<Config> {
       nda::fill(i_ha.hiv_negative_pop, 0.0);
       i_ha.Xhivn_incagerr = 0.0;
 
-      for (int a = adult_incid_first_age_group; a < pAG; ++a) {
+      for (int a = p_idx_hiv_first_adult; a < pAG; ++a) {
         i_ha.hiv_negative_pop(a) = n_dp.p_totpop(a, s) - n_ha.p_hivpop(a, s);
       }
 
       for (int a = adult_incid_first_age_group; a < adult_incid_last_age_group; ++a) {
-        i_ha.Xhivn_incagerr += p_ha.incidence_rate_ratio_age(a - adult_incid_first_age_group, s, t) *
+        i_ha.Xhivn_incagerr += p_ha.incidence_rate_ratio_age(a - p_idx_hiv_first_adult, s, t) *
                                i_ha.hiv_negative_pop(a);
       }
 
       for (int a = SS::p_idx_hiv_first_adult; a < pAG; ++a) {
         i_ha.p_infections_ts(a, s) = i_ha.hiv_negative_pop(a) *
                                      i_ha.incidence_rate_sex(s) *
-                                     p_ha.incidence_rate_ratio_age(a - adult_incid_first_age_group, s, t) *
+                                     p_ha.incidence_rate_ratio_age(a - p_idx_hiv_first_adult, s, t) *
                                      i_ha.hiv_neg_aggregate(s) /
                                      i_ha.Xhivn_incagerr;
       }
@@ -597,53 +599,53 @@ struct AdultHivModelSimulation<Config> {
     auto& i_ha = intermediate.ha;
 
     i_ha.asfr_sum = 0.0;
-    for (int a = 0; a < hAG_fertility; ++a) {
+    for (int a = 0; a < p_fertility_age_groups; ++a) {
       i_ha.asfr_sum += p_dp.age_specific_fertility_rate(a, t);
     } // end a
 
     int a_idx_in = p_idx_fertility_first;
     n_ha.hiv_births = 0.0;
-    for (int a = 0; a < hAG_fertility; ++a) {
+    for (int ha = 0; ha < hAG_fertility; ++ha) {
       i_ha.nHIVcurr = 0.0;
       i_ha.nHIVlast = 0.0;
       i_ha.df = 0.0;
 
       for (int hd = 0; hd < hDS; ++hd) {
-        i_ha.nHIVcurr += n_ha.h_hivpop(hd, a, FEMALE);
-        i_ha.nHIVlast += c_ha.h_hivpop(hd, a, FEMALE);
+        i_ha.nHIVcurr += n_ha.h_hivpop(hd, ha, FEMALE);
+        i_ha.nHIVlast += c_ha.h_hivpop(hd, ha, FEMALE);
         for (int ht = 0; ht < hTS; ++ht) {
-          i_ha.nHIVcurr += n_ha.h_artpop(ht, hd, a, FEMALE);
-          i_ha.nHIVlast += c_ha.h_artpop(ht, hd, a, FEMALE);
+          i_ha.nHIVcurr += n_ha.h_artpop(ht, hd, ha, FEMALE);
+          i_ha.nHIVlast += c_ha.h_artpop(ht, hd, ha, FEMALE);
         } // end hTS
       } // end hDS
 
       auto total_pop = 0.0;
       auto asfr_w = 0.0;
-      for (int a_idx = a_idx_in; a_idx < (a_idx_in + hAG_span[a]); ++a_idx) {
+      for (int a_idx = a_idx_in; a_idx < (a_idx_in + hAG_span[ha]); ++a_idx) {
         total_pop += n_dp.p_totpop(a_idx, FEMALE);
         asfr_w += p_dp.age_specific_fertility_rate(a_idx - p_idx_fertility_first, t) / i_ha.asfr_sum;
       }
       //set up a_idx_in for the next loop
-      a_idx_in = a_idx_in + hAG_span[a];
-      asfr_w /= hAG_span[a];
+      a_idx_in = a_idx_in + hAG_span[ha];
+      asfr_w /= hAG_span[ha];
 
       i_ha.prev = i_ha.nHIVcurr / total_pop;
 
       for (int hd = 0; hd < hDS; ++hd) {
         i_ha.df += p_ha.local_adj_factor *
-          p_ha.fert_mult_by_age(a, t) *
+          p_ha.fert_mult_by_age(ha, t) *
           p_ha.fert_mult_off_art(hd) *
-          (n_ha.h_hivpop(hd, a, FEMALE) + c_ha.h_hivpop(hd, a, FEMALE)) / 2;
+          (n_ha.h_hivpop(hd, ha, FEMALE) + c_ha.h_hivpop(hd, ha, FEMALE)) / 2;
 
         // women on ART less than 6 months use the off art fertility multiplier
         i_ha.df += p_ha.local_adj_factor *
-          p_ha.fert_mult_by_age(a, t) *
+          p_ha.fert_mult_by_age(ha, t) *
           p_ha.fert_mult_off_art(hd) *
-          (n_ha.h_artpop(0, hd, a, FEMALE) + c_ha.h_artpop(0, hd, a, FEMALE)) / 2;
+          (n_ha.h_artpop(0, hd, ha, FEMALE) + c_ha.h_artpop(0, hd, ha, FEMALE)) / 2;
         for (int ht = 1; ht < hTS; ++ht) {
           i_ha.df += p_ha.local_adj_factor *
-            p_ha.fert_mult_on_art(a) *
-            (n_ha.h_artpop(ht, hd, a, FEMALE) + c_ha.h_artpop(ht, hd, a, FEMALE)) / 2;
+            p_ha.fert_mult_on_art(ha) *
+            (n_ha.h_artpop(ht, hd, ha, FEMALE) + c_ha.h_artpop(ht, hd, ha, FEMALE)) / 2;
         } // end hTS
       } // end hDS
 
@@ -654,13 +656,13 @@ struct AdultHivModelSimulation<Config> {
         i_ha.df = 1;
       }
 
-      n_ha.hiv_births_by_mat_age(a) = midyear_fertileHIV * p_dp.total_fertility_rate(t) *
+      n_ha.hiv_births_by_mat_age(ha) = midyear_fertileHIV * p_dp.total_fertility_rate(t) *
         i_ha.df / (i_ha.df * i_ha.prev + 1 - i_ha.prev) *
         asfr_w;
 
 
-      n_ha.hiv_births += n_ha.hiv_births_by_mat_age(a);
-    } // end a
+      n_ha.hiv_births += n_ha.hiv_births_by_mat_age(ha);
+    } // end ha
   };
 
 

--- a/leapfrog-core/include/models/child_model_simulation.hpp
+++ b/leapfrog-core/include/models/child_model_simulation.hpp
@@ -799,10 +799,11 @@ struct ChildModelSimulation<Config> {
   void art_eligibility_by_age() {
     const auto& p_hc = pars.hc;
     auto& n_hc = state_next.hc;
+    const int hc_art_elig_age = std::min(p_hc.hc_art_elig_age(t), hcAG_end);
 
     // all children under a certain age eligible for ART
     for (int s = 0; s < NS; ++s) {
-      for (int a = 0; a < p_hc.hc_art_elig_age(t); ++a) {
+      for (int a = 0; a < hc_art_elig_age; ++a) {
         for (int cat = 0; cat < hcTT; ++cat) {
           for (int hd = 0; hd < hc1DS; ++hd) {
             if (a < hc2_agestart) {
@@ -819,11 +820,12 @@ struct ChildModelSimulation<Config> {
   void art_eligibility_by_cd4() {
     const auto& p_hc = pars.hc;
     auto& n_hc = state_next.hc;
+    const int hc_art_elig_age = std::min(p_hc.hc_art_elig_age(t), hcAG_end);
 
     // all children under a certain CD4 eligible for ART
     for (int s = 0; s < NS; ++s) {
       for (int cat = 0; cat < hcTT; ++cat) {
-        for (int a = p_hc.hc_art_elig_age(t); a < hcAG_end; ++a) {
+        for (int a = hc_art_elig_age; a < hcAG_end; ++a) {
           for (int hd = 0; hd < hc1DS; ++hd) {
             if (hd >= p_hc.hc_art_elig_cd4(a, t)) {
               if (a < hc2_agestart) {
@@ -1161,7 +1163,11 @@ struct ChildModelSimulation<Config> {
         } // end hc1DS
       } // end NS
     } // end dur
-    i_hc.hc_art_deaths(0) = i_hc.hc_art_deaths(1) + i_hc.hc_art_deaths(2) + i_hc.hc_art_deaths(3);
+
+    i_hc.hc_art_deaths(0) = 0.0;
+    for (int hca = 1; hca < hcAG_coarse; ++hca) {
+     i_hc.hc_art_deaths(0) += i_hc.hc_art_deaths(hca);
+    }
   };
 
   void progress_time_on_art(int curr_t_idx, int end_t_idx) {
@@ -1246,9 +1252,11 @@ struct ChildModelSimulation<Config> {
           }
         }
       }
-      i_hc.total_art_last_year(0) = i_hc.total_art_last_year(1) +
-                                    i_hc.total_art_last_year(2) +
-                                    i_hc.total_art_last_year(3);
+
+      i_hc.total_art_last_year(0) = 0.0;
+      for (int hca = 1; hca < hcAG_coarse; ++hca) {
+	i_hc.total_art_last_year(0) += i_hc.total_art_last_year(hca);
+      }
 
       for (int ag = 1; ag < hcAG_coarse; ++ag) {
         if (i_hc.total_art_last_year(0) > 0.0) {
@@ -1282,9 +1290,11 @@ struct ChildModelSimulation<Config> {
       } else if (p_hc.hc_art_is_age_spec(t - 1)) {
         // ART entered as number last year but this year isn't then aggregate
         // ages
-        i_hc.total_art_last_year(0) = p_hc.hc_art_val(1, t - 1) +
-                                      p_hc.hc_art_val(2, t - 1) +
-                                      p_hc.hc_art_val(3, t - 1);
+
+	i_hc.total_art_last_year(0) = 0.0;
+	for (int hca = 1; hca < hcAG_coarse; ++hca) {
+	  i_hc.total_art_last_year(0) += p_hc.hc_art_val(hca, t - 1);
+	}
       } else {
         // Last year was age aggregated and a number so use previous value
         i_hc.total_art_last_year(0) = p_hc.hc_art_val(0, t - 1);
@@ -1455,10 +1465,13 @@ struct ChildModelSimulation<Config> {
             for (int hd = 0; hd < hc1DS; ++hd) {
               auto& coarse_hc_adj = i_hc.hc_adj(hc_age_coarse[a]);
               auto& coarse_hc_art_scalar = i_hc.hc_art_scalar(hc_age_coarse[a]);
-              auto hc_art_val_sum = p_hc.hc_art_val(0, t) + p_hc.hc_art_val(1, t) +
-                                    p_hc.hc_art_val(2, t) + p_hc.hc_art_val(3, t);
-              auto hc_art_val_sum_last = p_hc.hc_art_val(0, t - 1) + p_hc.hc_art_val(1, t - 1) +
-                                         p_hc.hc_art_val(2, t - 1) + p_hc.hc_art_val(3, t - 1);
+
+              auto hc_art_val_sum = 0.0;
+              auto hc_art_val_sum_last = 0.0;
+              for (int hca = 0; hca < hcAG_coarse; ++hca) {
+                hc_art_val_sum += p_hc.hc_art_val(hca, t);
+                hc_art_val_sum_last += p_hc.hc_art_val(hca, t - 1);
+              }
               if (hc_art_val_sum + hc_art_val_sum_last <= 0.0) {
                 coarse_hc_art_scalar = 0.0;
               } else {


### PR DESCRIPTION
I'm pushing this PR separate from wider age 10-14 extensions as I think useful to have focused review to patches.

This addresses two fragilities that could lead to segfaults if parameter inputs or state space changes: 
* Cap upper age limit on child ART eligibility to ensure loop doesn't extend beyond end of array [we've discussed this issue before]
* Remove hard-coded array indices

Tip of the cap to Codex for helping pin down the first issue.