### PR TITLE
one commit to end them all

### DIFF
--- a/delphi/LeapfrogInterface.pas
+++ b/delphi/LeapfrogInterface.pas
@@ -260,8 +260,8 @@ end;
 type
   LeapfrogHivChildParamsView = record
   private
-    hcNosocomial: PDouble;
-    hcNosocomialLength: Integer;
+    hcNosocomialInfectionsByAge: PDouble;
+    hcNosocomialInfectionsByAgeLength: Integer;
     hc1Cd4Dist: PDouble;
     hc1Cd4DistLength: Integer;
     hc1Cd4Mort: PDouble;
@@ -341,7 +341,7 @@ end;
 type
   LeapfrogHivChildParams = class
   public
-    hcNosocomial: TGBFixedArray<Double>;
+    hcNosocomialInfectionsByAge: TGBFixedArray<Double>;
     hc1Cd4Dist: TGBFixedArray<Double>;
     hc1Cd4Mort: TGBFixedArray<Double>;
     hc2Cd4Mort: TGBFixedArray<Double>;
@@ -974,7 +974,7 @@ end;
 
 destructor LeapfrogHivChildParams.Destroy;
 begin;
-  hcNosocomial.Free;
+  hcNosocomialInfectionsByAge.Free;
   hc1Cd4Dist.Free;
   hc1Cd4Mort.Free;
   hc2Cd4Mort.Free;
@@ -1037,8 +1037,8 @@ end;
 
 function LeapfrogHivChildParams.getView(): LeapfrogHivChildParamsView;
 begin;
-  Result.hcNosocomial := PDouble(hcNosocomial.data);
-  Result.hcNosocomialLength := hcNosocomial.GetLength();
+  Result.hcNosocomialInfectionsByAge := PDouble(hcNosocomialInfectionsByAge.data);
+  Result.hcNosocomialInfectionsByAgeLength := hcNosocomialInfectionsByAge.GetLength();
   Result.hc1Cd4Dist := PDouble(hc1Cd4Dist.data);
   Result.hc1Cd4DistLength := hc1Cd4Dist.GetLength();
   Result.hc1Cd4Mort := PDouble(hc1Cd4Mort.data);
@@ -1472,7 +1472,7 @@ procedure LeapfrogHivChildParams.writeToDisk(dir: string);
 begin;
   if not DirectoryExists(dir) then
     ForceDirectories(dir);
-  hcNosocomial.WriteToDisk(IncludeTrailingPathDelimiter(dir) +  'hcNosocomial');
+  hcNosocomialInfectionsByAge.WriteToDisk(IncludeTrailingPathDelimiter(dir) +  'hcNosocomialInfectionsByAge');
   hc1Cd4Dist.WriteToDisk(IncludeTrailingPathDelimiter(dir) +  'hc1Cd4Dist');
   hc1Cd4Mort.WriteToDisk(IncludeTrailingPathDelimiter(dir) +  'hc1Cd4Mort');
   hc2Cd4Mort.WriteToDisk(IncludeTrailingPathDelimiter(dir) +  'hc2Cd4Mort');

--- a/goals/pyproject.toml
+++ b/goals/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
     "docopt>=0.6.2",
     "pytest>=8.3.5",
     "avenir-spectrum-import-pjnz>=0.1.5",
-    "avenir-spectrum-common>=0.1.6"
+    "avenir-spectrum-common>=0.1.9"
 ]
 
 # Uncomment and set file path to use local development versions

--- a/goals/uv.lock
+++ b/goals/uv.lock
@@ -38,20 +38,21 @@ wheels = [
 
 [[package]]
 name = "avenir-spectrum-common"
-version = "0.1.6"
+version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "avenir-common" },
     { name = "loguru" },
     { name = "numpy" },
+    { name = "openpyxl" },
     { name = "pandas" },
     { name = "pydantic" },
     { name = "requests" },
     { name = "ujson" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/b3/18518cc96e056022d7cf8af869422e803cf85882d3493e48825eaaf8e94f/avenir_spectrum_common-0.1.6.tar.gz", hash = "sha256:c9e2fb7d3cc466ab73797a843fb414e3bc1ae15c64faf16672d1c2a6468ccdc9", size = 641352, upload-time = "2026-06-04T12:42:54.323Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/0e/f9cde67161754bedffec2563a041ccd52fb3732c32ad59417573e6411385/avenir_spectrum_common-0.1.9.tar.gz", hash = "sha256:b92de27a3b3259ad33a0971da85f4c44a2cc92e35b4b7e65f5412ce563ddb1c7", size = 642991, upload-time = "2026-06-15T08:53:25.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/18/847585e7247ca56b85f8a1d31a24a6f5ad36f1e611d0861e1252f5fcd7f4/avenir_spectrum_common-0.1.6-py3-none-any.whl", hash = "sha256:3d140e780ce561b6b577ba69f732187cabe2ed49d2962ecc462674bc94c3f7cd", size = 721023, upload-time = "2026-06-04T12:42:56.407Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ed/64c8861b2586c8fd5503163d73a639e7eeabb48332688305a30c361d6a2d/avenir_spectrum_common-0.1.9-py3-none-any.whl", hash = "sha256:dd0e7aa965d77f12352f85201f20ec2a44aa21765a946f69956956fd5ed7b842", size = 722548, upload-time = "2026-06-15T08:53:23.449Z" },
 ]
 
 [[package]]
@@ -456,6 +457,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "h5py"
 version = "3.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -559,7 +569,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "avenir-spectrum-common", specifier = ">=0.1.6" },
+    { name = "avenir-spectrum-common", specifier = ">=0.1.9" },
     { name = "avenir-spectrum-import-pjnz", specifier = ">=0.1.5" },
     { name = "deepdiff", specifier = ">=8.4.2" },
     { name = "docopt", specifier = ">=0.6.2" },
@@ -656,6 +666,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
     { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
     { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]

--- a/leapfrog-core/include/leapfrog.hpp
+++ b/leapfrog-core/include/leapfrog.hpp
@@ -168,9 +168,9 @@ struct Leapfrog {
         if constexpr (ModelVariant::run_hiv_simulation) {
           hiv_dp.run_hivpop_end_year_migration();
         }
-        if constexpr (ModelVariant::run_child_model) {
-          hiv_dp.run_hc_hivpop_end_year_migration();
-        }
+      }
+      if constexpr (ModelVariant::run_child_model) {
+        hiv_dp.run_hc_hivpop_end_year_migration();
       }
 
       if constexpr (ModelVariant::run_spectrum_model) {

--- a/leapfrog-core/include/models/child_model_simulation.hpp
+++ b/leapfrog-core/include/models/child_model_simulation.hpp
@@ -657,15 +657,18 @@ struct ChildModelSimulation<Config> {
     auto& n_hc = state_next.hc;
 
     for (int s = 0; s < NS; ++s) {
-      // Run only first 5 age groups in total population 0, 1, 2, 3, 4
-      for (int a = 0; a < hc2_agestart; ++a) {
-        if (p_hc.hc_nosocomial(t) > 0) {
-          // 5.0 is used because we want to evenly distribute across the 5 age groups in 0-4
-          n_ha.p_infections(a, s) = p_hc.hc_nosocomial(t) / (5.0 * NS);
-          // Putting all nosocomial acquired HIV infections in perinatally acquired infection timing and highest CD4 category to match Spectrum implementation
-          n_hc.hc1_hivpop(0, 0, a, s) += n_ha.p_infections(a, s);
+      for (int a = 0; a < hcAG_end; ++a) {
+        const int ag = hc_age_coarse[a] - 1;
+        if (p_hc.hc_nosocomial_infections_by_age(ag, t) > 0) {
+          auto infections = p_hc.hc_nosocomial_infections_by_age(ag, t) / (5.0 * NS);
+          n_ha.p_infections(a, s) += infections;
+          if (a < hc2_agestart) {
+            n_hc.hc1_hivpop(0, 0, a, s) += infections;
+          } else {
+            n_hc.hc2_hivpop(0, 0, a - hc2_agestart, s) += infections;
+          }
         }
-      } // end a
+      }
     } // end NS
   };
 

--- a/leapfrog-core/include/models/hiv_demographic_projection.hpp
+++ b/leapfrog-core/include/models/hiv_demographic_projection.hpp
@@ -389,9 +389,9 @@ struct HivDemographicProjection<Config> {
     auto& n_hc = state_next.hc;
     const auto& p_hc = pars.hc;
 
-    real_type deaths_migrate = 0.0;
     for (int s = 0; s < NS; ++s) {
       for (int a = 0; a < hcAG_end; ++a) {
+        real_type deaths_migrate = 0.0;
         deaths_migrate -= n_ha.p_deaths_background_hivpop(a, s);
         if (opts.proj_period_int == PROJPERIOD_MIDYEAR) {
           deaths_migrate += n_ha.p_net_migration_hivpop(a, s);

--- a/leapfrog-core/model_schemas/configs/HcConfig.json
+++ b/leapfrog-core/model_schemas/configs/HcConfig.json
@@ -13,6 +13,7 @@
       "hc1AG_c": 2,
       "hc2AG": 10,
       "hc2AG_c": 1,
+      "hcAG_c": 3,
       "hc_infant": 2,
       "hcTT": 4,
       "hcTT_expanded": 5,
@@ -47,9 +48,9 @@
     }
   },
   "pars": {
-      "hc_nosocomial": {
+      "hc_nosocomial_infections_by_age": {
         "num_type": "real_type",
-        "dims": ["opts.proj_steps"]
+        "dims": ["ss:hcAG_c", "opts.proj_steps"]
       },
       "hc1_cd4_dist": {
         "num_type": "real_type",

--- a/leapfrog-core/model_schemas/configs/HcConfig.json
+++ b/leapfrog-core/model_schemas/configs/HcConfig.json
@@ -50,7 +50,7 @@
   "pars": {
       "hc_nosocomial_infections_by_age": {
         "num_type": "real_type",
-        "dims": ["ss:hcAG_c", "opts.proj_steps"]
+        "dims": ["SS::hcAG_c", "opts.proj_steps"]
       },
       "hc1_cd4_dist": {
         "num_type": "real_type",

--- a/leapfrogr/R/process_pjnz_hc.R
+++ b/leapfrogr/R/process_pjnz_hc.R
@@ -413,9 +413,10 @@ process_pjnz_hc <- function(dat, pars, dim_vars, use_coarse_age_groups = FALSE, 
   pars$breastfeeding_duration_art <- pars$infant_feeding_options[, "art", ] / 100
   pars$breastfeeding_duration_no_art <- pars$infant_feeding_options[, "no art", ] / 100
 
-  ##TODO: change this in leapfrog to be by multiple ages
-  pars$hc_nosocomial <- pars$nosocomial_infections_by_age[1, ]
-
+  ## Nosocomial infections by child age group (0-4, 5-9, 10-14); absent in older PJNZ files
+  if (is.null(pars$hc_nosocomial_infections_by_age)) {
+    pars$hc_nosocomial_infections_by_age <- matrix(0, nrow = 3, ncol = length(proj_years))
+  }
   pars$hc1_cd4_dist <- pars$child_dist_new_infections_cd4 / 100
 
   #############################################################

--- a/leapfrogr/tests/testthat/test-child-model.R
+++ b/leapfrogr/tests/testthat/test-child-model.R
@@ -189,6 +189,109 @@ test_that("Model outputs are consistent", {
   expect_true(all(abs(c2$diff) < 1e-5))
 })
 
+test_that("Nosocomial infections map to the correct child age bands", {
+  parameters <- read_parameters(test_path("testdata/child_parms_full.h5"))
+  parameters$hc_nosocomial_infections_by_age[] <- 0
+  
+  ## VT/BF only contribute to p_infections at ages 0-2, so ages 3-14 (R indices
+  ## 4:15) are zero in the baseline and only receive nosocomial infections.
+  ## This lets us use exact equality to verify the hc_age_coarse[a]-1 routing.
+  
+  pars1 <- parameters; pars1$hc_nosocomial_infections_by_age[1, ] <- 100
+  pars2 <- parameters; pars2$hc_nosocomial_infections_by_age[2, ] <- 100
+  pars3 <- parameters; pars3$hc_nosocomial_infections_by_age[3, ] <- 100
+  
+  out1 <- run_model(pars1, "ChildModel", 1970:2030)
+  out2 <- run_model(pars2, "ChildModel", 1970:2030)
+  out3 <- run_model(pars3, "ChildModel", 1970:2030)
+  
+  ## Row 1 → ages 0-4 only; ages 5-14 stay at their baseline (zero)
+  expect_true(sum(out1$p_infections[4:5, , ]) > 0)    # ages 3-4 receive infections
+  expect_true(all(out1$p_infections[6:15, , ] == 0))  # ages 5-14 untouched
+  
+  ## Row 2 → ages 5-9 only; ages 3-4 and 10-14 stay at zero
+  expect_true(all(out2$p_infections[4:5, , ]  == 0))  # ages 3-4 untouched
+  expect_true(sum(out2$p_infections[6:10, , ]) > 0)   # ages 5-9 receive infections
+  expect_true(all(out2$p_infections[11:15, , ] == 0)) # ages 10-14 untouched
+  
+  ## Row 3 → ages 10-14 only; ages 5-9 stay at zero
+  expect_true(all(out3$p_infections[6:10, , ]  == 0)) # ages 5-9 untouched
+  expect_true(sum(out3$p_infections[11:15, , ]) > 0)  # ages 10-14 receive infections
+  
+  ## Infections are divided evenly across the 5 single-year ages in each band
+  ## (the C++ divides by 5.0 * NS, so every age/sex cell gets the same value).
+  ## Year index 1 is the initial state (1970, pre-simulation); index 2 is the
+  ## first computed year (1971) where nosocomial infections are first applied.
+  noso_per_age_sex <- 100 / (5 * 2)
+  expect_equal(out2$p_infections[6:10, , 2],
+               matrix(noso_per_age_sex, nrow = 5, ncol = 2),
+               tolerance = 1e-10, ignore_attr = TRUE)
+  expect_equal(out3$p_infections[11:15, , 2],
+               matrix(noso_per_age_sex, nrow = 5, ncol = 2),
+               tolerance = 1e-10, ignore_attr = TRUE)
+})
+
+test_that("Model outputs are consistent for midyear projections", {
+  parameters <- read_parameters(test_path("testdata/child_parms_full.h5"))
+  parameters$projection_period <- "midyear"
+  out <- run_model(parameters, "ChildModel", 1970:2030)
+  
+  ## Regression test: run_hc_hivpop_end_year_migration() was previously only
+  ## called for calendar-year projections.
+  hc1_hiv <- apply(out$hc1_hivpop, c(3,4,5), sum)
+  hc1_art <- apply(out$hc1_artpop, c(3,4,5), sum)
+  hc1 <- hc1_hiv + hc1_art
+  dimnames(hc1) <- list(age = 0:4, sex = c('male','female'), year = 1970:2030)
+  p_hiv <- out$p_hivpop[1:5, , ]
+  dimnames(p_hiv) <- list(age = 0:4, sex = c('male','female'), year = 1970:2030)
+  hc1_df <- as.data.frame(as.table(hc1))
+  out_df <- as.data.frame(as.table(p_hiv))
+  colnames(hc1_df) <- c("Var1", "Var2", "Var3", "strat")
+  colnames(out_df) <- c("Var1", "Var2", "Var3", "pop")
+  c1 <- hc1_df %>%
+    dplyr::inner_join(out_df, by = c("Var1", "Var2", "Var3")) %>%
+    dplyr::mutate(diff = strat - pop)
+  expect_true(all(abs(c1$diff) < 1e-5))
+  
+  hc2_hiv <- apply(out$hc2_hivpop, c(3,4,5), sum)
+  hc2_art <- apply(out$hc2_artpop, c(3,4,5), sum)
+  hc2 <- hc2_hiv + hc2_art
+  dimnames(hc2) <- list(age = 5:14, sex = c('male','female'), year = 1970:2030)
+  p_hiv <- out$p_hivpop[6:15, , ]
+  dimnames(p_hiv) <- list(age = 5:14, sex = c('male','female'), year = 1970:2030)
+  hc2_df <- as.data.frame(as.table(hc2))
+  out_df <- as.data.frame(as.table(p_hiv))
+  colnames(hc2_df) <- c("Var1", "Var2", "Var3", "strat")
+  colnames(out_df) <- c("Var1", "Var2", "Var3", "pop")
+  c2 <- hc2_df %>%
+    dplyr::inner_join(out_df, by = c("Var1", "Var2", "Var3")) %>%
+    dplyr::mutate(diff = strat - pop)
+  expect_true(all(abs(c2$diff) < 1e-5))
+})
+
+test_that("Nosocomial infections are applied across all three child age groups", {
+  parameters <- read_parameters(test_path("testdata/child_parms_full.h5"))
+  
+  ## Baseline: zero out all nosocomial infections
+  parameters_none <- parameters
+  parameters_none$hc_nosocomial_infections_by_age[] <- 0
+  out_none <- run_model(parameters_none, "ChildModel", 1970:2030)
+  
+  ## Apply nosocomial infections only to age groups 5-9 and 10-14 (rows 2 and 3).
+  ## Regression test: previously only age group 0-4 received infections.
+  parameters_older <- parameters
+  parameters_older$hc_nosocomial_infections_by_age[] <- 0
+  parameters_older$hc_nosocomial_infections_by_age[2, ] <- 100
+  parameters_older$hc_nosocomial_infections_by_age[3, ] <- 100
+  out_older <- run_model(parameters_older, "ChildModel", 1970:2030)
+  
+  ## Ages 5-14 should gain infections; ages 0-4 should be unaffected
+  expect_true(
+    sum(out_older$p_infections[6:15, , ]) > sum(out_none$p_infections[6:15, , ])
+  )
+  expect_equal(out_older$p_infections[1:5, , ], out_none$p_infections[1:5, , ])
+})
+
 test_that("Female 15-49y pop aligns", {
   testthat::skip("Skipping this test because the adult populations currently do not align")
   parameters <- read_parameters(test_path("testdata/child_parms_full.h5"))

--- a/leapfrogr/tests/testthat/test-process-pjnz.R
+++ b/leapfrogr/tests/testthat/test-process-pjnz.R
@@ -69,8 +69,7 @@ test_that("process_pjnz extract_child_params adds child-specific parameters", {
   pars_adult <- process_pjnz(bwa_pmtct_pjnz)
   pars_child <- process_pjnz(bwa_pmtct_pjnz, extract_child_params = TRUE)
 
-  child_pars <- c("hc_nosocomial", "hc1_cd4_dist", "hc1_cd4_mort",
-                  "hc2_cd4_mort", "hc1_cd4_prog", "hc2_cd4_prog",
+  child_pars <- c("hc_nosocomial_infections_by_age", "hc1_cd4_dist", "hc1_cd4_mort",                  "hc2_cd4_mort", "hc1_cd4_prog", "hc2_cd4_prog",
                   "ctx_val", "PMTCT", "vertical_transmission_rate")
   expect_true(all(child_pars %in% names(pars_child)))
   expect_false(any(child_pars %in% names(pars_adult)))


### PR DESCRIPTION
Closes issue #335. 

Three changes implemented:

  1. Issue raised by Jeff: Fix child HIV population migration for midyear projections (leapfrog.hpp) run_hc_hivpop_end_year_migration() was inside a PROJPERIOD_CALENDAR-only guard. For midyear projections, net migration was applied to p_hivpop for child ages (in run_hiv_and_art_stratified_deaths_and_migration) but never to hc1_hivpop/hc2_hivpop, causing  the two population representations to diverge. The fix moves the child migration call outside the calendar-year guard so it runs unconditionally when the child model is active. This wasn't an issue for the test file as it didn't use mid year projections. 
  2. Fix accumulating deaths_migrate variable (hiv_demographic_projection.hpp) In run_hc_hiv_and_art_stratified_deaths_and_migration(), deaths_migrate was declared once before the age and sex loops and accumulated across every iteration. Each age/sex combination was therefore adding to a running total from prior iterations rather than computing its own value. The fix moves the declaration inside the inner loop so it resets to  zero per age/sex/year.
  3. Extend nosocomial infections to all three child age groups and rename parameter (child_model_simulation.hpp, config, R interface) nosocomial_infections() only populated hc1 (ages 0–4); the 5–9 and 10–14 rows of the input were silently ignored. The fix extends the function to apply infections to hc2 age groups as   well, using the correct hc2_hivpop index and += (previously =). Alongside this, the parameter is renamed from the ambiguous hc_nosocomial/nosocomial_infections_by_age to hc_nosocomial_infections_by_age throughout the codebase (config schema, generated  C++/R/Python adapters, R reader, and tests), and its shape changes from a 1-D vector to a 3×proj_steps matrix — one row per coarse child age group.


*Note that merge conflicts were resolved by me, and then investigation into Jeff's problem noted in #335 was mostly done by Claude.*

*Sorry for the _newer in the branch name*