### PR TITLE
Fix some out of bounds accessors, and a couple of buggy bits of code

### DIFF
--- a/leapfrog-core/include/models/goals_simulation.hpp
+++ b/leapfrog-core/include/models/goals_simulation.hpp
@@ -876,9 +876,6 @@ public:
         if (rg == RG_NONE || rg == RG_IDU) {
           pulse = 0.0;
         }
-        if (rg == S_FEMALE && rg == RG_MSM) {
-          pulse = 0.0;
-        }
 
         for (int hd = CD4_PRIM; hd <= CD4_LT50; ++hd) {
           int hd_hds = 0;  // set prim

--- a/leapfrog-core/include/models/goals_simulation.hpp
+++ b/leapfrog-core/include/models/goals_simulation.hpp
@@ -1170,7 +1170,7 @@ public:
           i_hv.dp_pop_1549_hiv(hd, s) += n_ha.h_hivpop(hd_hds, a_hv, s);
 
           double hivpop_h = n_ha.h_hivpop(hd_hds, a_hv, s);
-          double hivpop_h1 = n_ha.h_hivpop(hd_hds - 1, a_hv, s);
+          double hivpop_h1 = n_ha.h_hivpop(hd_hds, a_hv, s);
 
           i_hv.dp_pop_sex_age_hiv(POP_H_NoART, s) += hivpop_h;
           i_hv.dp_aging_denom_1549(POP_H_NoART, hd, s) += hivpop_h;
@@ -1186,7 +1186,7 @@ public:
               n_ha.h_hiv_deaths_no_art(hd_hds, a_hv, s);
           if (hd > CD4_GT500) {
             i_hv.dp_hiv_cd4_progression(hd - 1, s) +=
-                p_ha.cd4_progression(hd_hds - 1, a_hv, s) * hivpop_h1;
+                p_ha.cd4_progression(hd_hds, a_hv, s) * hivpop_h1;
           }
 
           for (int ht = 0; ht < nART; ++ht) {
@@ -1245,8 +1245,6 @@ public:
     nda::fill(i_hv.art_alpha, 0.0);  // mort rate, hiv on ART
 
     // aggregate rates
-    nda::fill(i_hv.hiv_exit_rates, 0.0);  // total exit rate, hiv not on ART
-    nda::fill(i_hv.art_exit_rates, 0.0);  // total exit rate, hiv on ART
     nda::fill(
         i_hv.hiv_stage_progressors, 0.0
     );  // progression rate, hiv not on ART
@@ -1376,23 +1374,6 @@ public:
         }
         i_hv.rate_aging_50(POP_H_OnART, hd, s) =
             (denominator != 0.0) ? numerator / denominator : 0.0;
-      }
-
-      // aggregate exit rates  CDP review if still needed - seems not
-      for (int hd = CD4_GT500; hd < CD4_LT50; ++hd) {
-        for (int rg = RG_NONE; rg <= RG_TOTAL; ++rg) {
-          i_hv.hiv_exit_rates(rg, hd, s) = i_hv.background_death_rate(s)
-                  + i_hv.hiv_mu(hd, s)
-                  + (p_hv.b_behav_properties(rg, DUR_AVG) > 0.0)
-              ? (1 / p_hv.b_behav_properties(rg, DUR_AVG))
-              : 0.0 + i_hv.rate_aging_50(POP_H_NoART, hd, s);
-
-          i_hv.art_exit_rates(rg, hd, s) = i_hv.background_death_rate(s)
-                  + i_hv.art_alpha(hd, s)
-                  + (p_hv.b_behav_properties(rg + RG_NONE_F3, DUR_AVG) > 0.0)
-              ? (1 / p_hv.b_behav_properties(rg + RG_NONE_F3, DUR_AVG))
-              : 0.0 + i_hv.rate_aging_50(POP_H_OnART, hd, s);
-        }
       }
     }
   }
@@ -2580,10 +2561,7 @@ public:
         // needle sharing
         double idu_inf = 0.0;
         idu_inf = p_hv.b_foi_idu(s, t) * i_hv.r_mult(RG_ALL, S_ALL) * PrevB
-            * SusceptibleIDU;  //*
-        (1 - p_hv.prep_cov(s, rg, t) * i_hv.prep_effect(rg, t));
-        //+_ForceNeedleTransmIDU*SusceptibleIDU;//no explicit needle sharing
-        //mechanism
+            * SusceptibleIDU;
         n_hv.new_inf_vrs(v, rg, s) = std::max(idu_inf, 0.0);
 
         SusceptibleIDU = n_hv.adults(v, RG_IDU, CD4_NEG, s);
@@ -3058,7 +3036,7 @@ public:
             for (int hd = CD4_GT500; hd <= CD4_LT50; ++hd) {
               if (hd == CD4_GT500) {
                 prop1[hd] = (eligible_art_vrhs[v][rg][hd][s]
-                             + eligible_art_vrhs[v][CD4_PRIM][rg][s])
+                             + eligible_art_vrhs[v][rg][CD4_PRIM][s])
                     / sum_elig_art[v][rg][s];
               } else {
                 prop1[hd] =
@@ -3725,7 +3703,7 @@ private:
           for (int rg = RG_LRH; rg <= RG_IDU; ++rg) {
             pop_reached += n_hv.adults(VAC_ALL, rg, CD4_NEG, S_FEMALE)
                 * p_hv.prep_method_mix(S_FEMALE, rg, m, t)
-                * p_hv.prep_cov(S_MALE, rg, t);
+                * p_hv.prep_cov(S_FEMALE, rg, t);
           }
 
           break;

--- a/leapfrog-core/model_schemas/configs/HvConfig.json
+++ b/leapfrog-core/model_schemas/configs/HvConfig.json
@@ -228,7 +228,7 @@
 
     "rn_coverage": {
       "num_type": "real_type",
-      "dims": ["SS::nIntervnRN", "opts.proj_steps"] 
+      "dims": ["SS::nIntervnRN", "opts.proj_steps"]
     },
 
     "rn_poc_cov": {
@@ -379,16 +379,6 @@
    "rate_aging_50": {
       "num_type": "real_type",
       "dims": ["SS::nHIV", "SS::nCD4","SS::nNS"]
-    },
-
-    "hiv_exit_rates": {
-      "num_type": "real_type",
-      "dims": ["SS::nHIV", "SS::nCD4p","SS::nNS"]
-    },
-
-     "art_exit_rates": {
-      "num_type": "real_type",
-      "dims": ["SS::nRG", "SS::nCD4a+1","SS::nNS"]
     },
 
     "hiv_stage_exits": {
@@ -604,7 +594,7 @@
       "num_type": "real_type",
       "dims": ["SS::nVAC+1","SS::nRG+1","SS::nCD4+1","SS::nNS+1"]
     },
-    
+
     "total_deaths": {
       "num_type": "real_type"
     },


### PR DESCRIPTION
This PR contains a few goals fixes which I have commented about inline. But there are a few other potential bugs (let's chat about these tomorrow):
1. ~Unreachable code blocks, which have a continue silently skip a bunch of code~
   1. ~Line 1641, 1952 and 1737~ - _we chatted about these and wanted to keep them for now, will be enabled soon_
3. Wrong value bugs `pop_reached` 
4. Dead methods:
   1. ~`calc_rescale_infections` is never called~ _will be used in the near future_
   2. `add_new_infections_goals` - call site is commented out
   3. `add_new_infections2` - is never called
   5. ~`calc_adj_matrix` - is never called~ _will be used in the near future_ 
   6. ~`calc_behav_matrix_impacts` is never called~ _will be used in the near future_
   7. `do_cd4_params_editor` is hardcoded to `true` on line 1244 so the else branch on line 1312-1346 is never run
   8. `rg_eligible_treat` is always false, bunch of code only runs if it is true
   9. `n_hv.new_infections` is always zero, it gets cleared with nda::fill on line 645
   10. `temp1`, `temp2` in `progress_hivp_and_art` are assigned but never read
   11. `totalSexActs` in `calc_new_infections` is shadowed by another delcaration at line 2229
   12. `double value` in `calc_resource_needs` only appears in commented out code, never used.
5. double literals should be replaced with `real_type`
6. ~line 869 `if (rg == S_FEMALE && rg == RG_MSM) {` can never both be true~ _chatted about this, this should be s == S_FEMALE, but I notice we have a guard for that check earlier on lines 859-861 so I have just removed this if statement as this would never be hit_
7. Rob A to look at why migration rate is always 0
