### PR TITLE
#247: set zero net migration if population is zero

### DIFF
--- a/leapfrog-core/include/models/general_demographic_projection.hpp
+++ b/leapfrog-core/include/models/general_demographic_projection.hpp
@@ -70,7 +70,8 @@ struct GeneralDemographicProjection<Config> {
       // Migration for ages 0, ..., 80+
       for (int a = 0; a < pAG; ++a) {
         // Calculate migration rate as number of net migrants divided by total pop.
-        i_dp.migration_rate(a, s) = p_dp.net_migration(a, s, t) == 0.0 ? 0.0 :
+	// If total population = 0, set net migration to 0 to avoid NaN
+        i_dp.migration_rate(a, s) = n_dp.p_totpop(a, s) == 0.0 ? 0.0 :
 	  p_dp.net_migration(a, s, t) / n_dp.p_totpop(a, s);
         n_dp.p_totpop(a, s) *= 1.0 + i_dp.migration_rate(a, s);
       }
@@ -109,7 +110,7 @@ struct GeneralDemographicProjection<Config> {
         // Get migration rate, as number of net migrants adjusted for survivorship
         // to end of period. Divide by 2 as (on average) half of deaths will
         // happen before they migrate. Then divide by total pop to get rate.
-        i_dp.migration_rate(a, s) = p_dp.net_migration(a, s, t) == 0.0 ? 0.0 :
+        i_dp.migration_rate(a, s) = n_dp.p_totpop(a, s) == 0.0 ? 0.0 :
 	                              p_dp.net_migration(a, s, t) *
                                       (1.0 + p_dp.survival_probability(a, s, t)) * 0.5 /
 	                              n_dp.p_totpop(a, s);


### PR DESCRIPTION
If there is zero population in a group, set the net migration rate to zero to avoid divide-by-zero error in calcuating net migration rate.

This means that zero migration would be applied, even if the input specifies a non-zero net migration.

Confirmed that this is the behaviour in Spectrum desktop (Delphi version)

Closes #247 